### PR TITLE
fix regexes in the feed settings

### DIFF
--- a/js/admin/feed_settings.js
+++ b/js/admin/feed_settings.js
@@ -27,13 +27,13 @@ var PODLOVE = PODLOVE || {};
 		function slugify( text ) {
 
 			// replace non letter or digits by -
-			text = text.replace(/[^-\w]+/, '-');
+			text = text.replace(/[^-\w]+/g, '-');
 
 			// trim
 			text = text.replace(/^-+|-+$/g, '');
 
 			// remove unwanted characters
-			text = text.replace(/[^-\w]+/, '');
+			text = text.replace(/[^-\w]+/g, '');
 
 			return text ? text : 'n-a';
 		}


### PR DESCRIPTION
the regex did not match all unwanted chars. entering /foo/bar/ (including the slashes) makes the preview go crazy; those chages fix them

![crazy-slug](https://f.cloud.github.com/assets/142237/463473/4573da08-b566-11e2-9dd2-6f6819235dc4.png)
