### PR TITLE
hide prompt label in auphonic metadata plugin

### DIFF
--- a/lib/modules/auphonic_production_data/js/auphonic_production_data.js
+++ b/lib/modules/auphonic_production_data/js/auphonic_production_data.js
@@ -60,6 +60,9 @@ var PODLOVE = PODLOVE || {};
 
 			field_cache = fields;
 
+			// hide prompt label which usually is placed above the title field
+			$('#title-prompt-text').addClass('screen-reader-text');
+
 			$.each(fields, function(field_id, remote_value) {
 				var input = $("#" + field_id)
 				    current_value = input.val();


### PR DESCRIPTION
when entering a episode slug with activated auphonic metadata plugin, the title get's fetched but the label above doesn't get removed

![title-prompt](https://f.cloud.github.com/assets/142237/463477/e9ffbb3c-b566-11e2-9246-4bec9950d7cb.png)
