### PR TITLE
fixing link to file type manager from migration assistant

### DIFF
--- a/lib/modules/migration/enclosure.php
+++ b/lib/modules/migration/enclosure.php
@@ -91,7 +91,7 @@ class Enclosure {
 				__( '<strong>Unknown mime type "%s"</strong> in post %s If you want to migrate files with this mime type, you need to create your own %sfile type%s', 'podlove' ),
 				$enclosure->mime_type,
 				sprintf( '<a href="%s" target="_blank">%s</a>', get_edit_post_link( $enclosure->post_id ), get_the_title( $enclosure->post_id ) ),
-				'<a href="?page=podlove_file_types_settings_handle" target="_blank">',
+				'<a href="?page=podlove_settings_settings_handle&podlove_tab=file-types" target="_blank">',
 				'</a>'
 			);
 			return $enclosure;	
@@ -127,7 +127,7 @@ class Enclosure {
 				__( '<strong>Unknown mime type "%s"</strong> in post %s If you want to migrate files with this mime type, you need to create your own %sfile type%s', 'podlove' ),
 				$enclosure->mime_type,
 				sprintf( '<a href="%s" target="_blank">%s</a>', get_edit_post_link( $enclosure->post_id ), get_the_title( $enclosure->post_id ) ),
-				'<a href="?page=podlove_file_types_settings_handle" target="_blank">',
+				'<a href="?page=podlove_settings_settings_handle&podlove_tab=file-types" target="_blank">',
 				'</a>'
 			);
 			return $enclosure;	
@@ -168,7 +168,7 @@ class Enclosure {
 				__( '<strong>Unknown extension "%s"</strong> in post %s If you want to migrate files with this extension, you need to create your own %sfile type%s', 'podlove' ),
 				$enclosure->extension,
 				sprintf( '<a href="%s" target="_blank">%s</a>', get_edit_post_link( $enclosure->post_id ), get_the_title( $enclosure->post_id ) ),
-				'<a href="?page=podlove_file_types_settings_handle" target="_blank">',
+				'<a href="?page=podlove_settings_settings_handle&podlove_tab=file-types" target="_blank">',
 				'</a>'
 			);
 			return $enclosure;


### PR DESCRIPTION
Current link to "?page=podlove_file_types_settings_handle" gives you a "You do not have permission to access this page."
