### PR TITLE
fix [podlove-podcast-contributor-list]

### DIFF
--- a/lib/modules/contributors/templates/podcast-contributor-table.twig
+++ b/lib/modules/contributors/templates/podcast-contributor-table.twig
@@ -10,7 +10,7 @@
 
 <table class="podlove-contributors-table">
 	<tbody>
-		{% for contributor in podcast.contributors({group: group, role: group, scope: 'global'}) %}
+		{% for contributor in podcast.contributors({group: group, role: group, scope: 'podcast'}) %}
 			{% if contributor.visible %}
 				{% include '@contributors/_contributor-table-row.twig' %}
 			{% endif %}


### PR DESCRIPTION
```
now only contributors set up in podcast settings are shown
```

I had problems with contributors showing up with the [podlove-podcast-contributor-list] shortcode that weren't set up in the podcast settings; in contrast to the help note there. The changed template is only used by this shortcode, therefore a change seems reasonable.
