### PR TITLE
Enable group and role selection in shortcodes

### DIFF
--- a/lib/modules/contributors/templates/contributor-comma-separated.twig
+++ b/lib/modules/contributors/templates/contributor-comma-separated.twig
@@ -1,5 +1,5 @@
 <span class="podlove-contributors">
-	{% for contributor in episode.contributors %}
+	{% for contributor in episode.contributors({group: group, role: role}) %}
 		{% if contributor.visible %}
 			<span>
 				{% if avatars == "yes" %}

--- a/lib/modules/contributors/templates/contributor-list.twig
+++ b/lib/modules/contributors/templates/contributor-list.twig
@@ -1,5 +1,5 @@
 <ul class="podlove-contributors">
-{% for contributor in episode.contributors %}
+{% for contributor in episode.contributors({group: group, role: role}) %}
 	{% if contributor.visible %}
 		<li>
 			{% if avatars == "yes" %}


### PR DESCRIPTION
Only the "table" variant of the podlove-podcast-contributor-list
allowed selection of contributor group and/or roles. Now this works
with cdv and list view too.
