### PR TITLE
use https for external javascript

### DIFF
--- a/lib/form/input/builder.php
+++ b/lib/form/input/builder.php
@@ -250,7 +250,7 @@ class Builder {
 				if( $(field).val().indexOf("@") == -1 ) {
 					url = $(field).val();
 				} else {
-					url = 'http://www.gravatar.com/avatar/' + CryptoJS.MD5( $(field).val() ) + '&amp;s=50';
+					url = 'https://www.gravatar.com/avatar/' + CryptoJS.MD5( $(field).val() ) + '&amp;s=50';
 
 				}	
 				$(field).parent().find("img").attr("src", url);

--- a/lib/helper.php
+++ b/lib/helper.php
@@ -714,7 +714,7 @@ function getFlattrScript() {
 		     var s = document.createElement('script'), t = document.getElementsByTagName('script')[0];
 		     s.type = 'text/javascript';
 		     s.async = true;
-		    s.src = 'http://api.flattr.com/js/0.6/load.js?mode=auto';
+		    s.src = 'https://api.flattr.com/js/0.6/load.js?mode=auto';
 		    t.parentNode.insertBefore(s, t);
 			 })();
 		/* ]]> */</script>\n";

--- a/lib/modules/bitlove/bitlove.php
+++ b/lib/modules/bitlove/bitlove.php
@@ -5,7 +5,7 @@ use \Podlove\Model;
 class Bitlove extends \Podlove\Modules\Base {
 
 	protected $module_name = 'Bitlove';
-	protected $module_description = 'Enable support for <a href="http://bitlove.org/" target="_blank">Bitlove</a>. Bitlove creates Torrents for all enclosures of an RSS/ATOM feed and seeds them.';
+	protected $module_description = 'Enable support for <a href="https://bitlove.org/" target="_blank">Bitlove</a>. Bitlove creates Torrents for all enclosures of an RSS/ATOM feed and seeds them.';
 	protected $module_group = 'external services';
 
 	public function load() {
@@ -49,7 +49,7 @@ class Bitlove extends \Podlove\Modules\Base {
 			return $bitlove_feed_url;
 		} else {
 			$subscribe_url = $feed->get_subscribe_url();
-			$url = 'http://api.bitlove.org/feed-lookup.json?url=' . $subscribe_url;
+			$url = 'https://api.bitlove.org/feed-lookup.json?url=' . $subscribe_url;
 
 			$curl = new \Podlove\Http\Curl();
 			$curl->request( $url, array(
@@ -110,7 +110,7 @@ class Bitlove extends \Podlove\Modules\Base {
 
 	public function inject_base() {
 		?>
-		<script src="http://bitlove.org/widget/base.js" type="text/javascript"></script>
+		<script src="https://bitlove.org/widget/base.js" type="text/javascript"></script>
 		<?php
 	}
 

--- a/lib/modules/contributors/js/admin.js
+++ b/lib/modules/contributors/js/admin.js
@@ -87,7 +87,7 @@ var PODLOVE = PODLOVE || {};
 	PODLOVE.add_contributor = function(options) {
 
 		if (!options.avatar) {
-			options.avatar = 'http://www.gravatar.com/avatar?d=mm';
+			options.avatar = 'https://www.gravatar.com/avatar?d=mm';
 		}
 
 		// visually add contributor

--- a/lib/modules/contributors/model/contributor.php
+++ b/lib/modules/contributors/model/contributor.php
@@ -148,7 +148,7 @@ class Contributor extends Base
 
 		$email = $email ? $email : $this->publicemail;
 
-		$url = 'http://www.gravatar.com/avatar/';
+		$url = 'https://www.gravatar.com/avatar/';
 		$url .= md5( strtolower( trim( $email ) ) );
 		$url .= "?s=$s&d=mm&r=g";
 		return $url;

--- a/lib/modules/contributors/templates/_contributor-table-flattr.twig
+++ b/lib/modules/contributors/templates/_contributor-table-flattr.twig
@@ -3,7 +3,7 @@
 	var s = document.createElement('script'), t = document.getElementsByTagName('script')[0];
 	s.type = 'text/javascript';
 	s.async = true;
-	s.src = 'http://api.flattr.com/js/0.6/load.js?mode=auto';
+	s.src = 'https://api.flattr.com/js/0.6/load.js?mode=auto';
 	t.parentNode.insertBefore(s, t);
 })();
 </script>

--- a/lib/settings/dashboard.php
+++ b/lib/settings/dashboard.php
@@ -50,14 +50,14 @@ class Dashboard {
 				        var s = document.createElement('script'), t = document.getElementsByTagName('script')[0];
 				        s.type = 'text/javascript';
 				        s.async = true;
-				        s.src = 'http://api.flattr.com/js/0.6/load.js?mode=auto';
+				        s.src = 'https://api.flattr.com/js/0.6/load.js?mode=auto';
 				        t.parentNode.insertBefore(s, t);
 				    })();
 				/* ]]> */</script>
 				<a class="FlattrButton" style="display:none;" rev="flattr;button:compact;" href="http://wordpress.org/extend/plugins/podlove-podcasting-plugin-for-wordpress/"></a>
 				<a href="http://www.cornify.com" onclick="cornify_add();return false;" style="text-decoration: none; color: #A7A7A7; float: right; font-size: 20px; line-height: 20px;"><i class="podlove-icon-heart"></i></a>
 				<noscript><a href="http://flattr.com/thing/728463/Podlove-Podcasting-Plugin-for-WordPress" target="_blank">
-				<img src="http://api.flattr.com/button/flattr-badge-large.png" alt="Flattr this" title="Flattr this" border="0" /></a></noscript>
+				<img src="https://api.flattr.com/button/flattr-badge-large.png" alt="Flattr this" title="Flattr this" border="0" /></a></noscript>
 			</li>
 		</ul>
 		<?php


### PR DESCRIPTION
Es gibt leider eine Fehlermeldung wenn man Podlove mit https betreibt. Dieser Patch behebt das Problem.

Ich habe alle http:///irgendwas/was.js durch https://irgendwas/was.js ersetzt und geprüft, das die neuen Scripte so zu finden sind (Doppelt nachsehen ist natürlich trotzdem besser).

Eine andere Möglichkeit wäre das Protokoll ganz weg zu lassen, also 

http:///irgendwas/was.js   -> ///irgendwas/was.js 

Aber da sehe ich den Vorteil nicht wirklich.

Gruß
Sven
