### PR TITLE
bloginfo_rss() -> get_bloginfo_rss()

### DIFF
--- a/lib/helper.php
+++ b/lib/helper.php
@@ -84,7 +84,7 @@ function get_landing_page_url() {
 
 	switch ($landing_page) {
 		case 'homepage':
-			return bloginfo_rss('url');
+			return get_bloginfo_rss('url');
 			break;
 		case 'archive':
 			if ( 'on' == \Podlove\get_setting( 'website', 'episode_archive' ) ) {
@@ -106,7 +106,7 @@ function get_landing_page_url() {
 	}
 
 	// always default to home page
-	return bloginfo_rss('url');
+	return get_bloginfo_rss('url');
 }
 
 function get_webplayer_setting( $name ) {


### PR DESCRIPTION
Wrong use of bloginfo_rss() here. bloginfo_rss() prints the bloginfo.
Use get_bloginfo_rss() instead.
