### PR TITLE
issue #479 Call to a member function get_file_url() on a non-object

### DIFF
--- a/lib/podcast_post_meta_box.php
+++ b/lib/podcast_post_meta_box.php
@@ -351,7 +351,7 @@ class Podcast_Post_Meta_Box {
 					'data-size' => ( is_object( $file ) ) ? $file->size : 0,
 					'data-episode-asset-id' => $asset->id,
 					'data-episode-id' => $episode->id,
-					'data-file-url' => $file->get_file_url()
+					'data-file-url' => ( is_object( $file ) ) ? $file->get_file_url() : ''
 				);
 
 				if ( $file )


### PR DESCRIPTION
wenn es noch kein File gibt (weil Episode neu angelegt wird zum Beispiel) kann .get_file_url() nicht auf null aufgerufen werden
