### PR TITLE
GeoIP could accept broken downloads

### DIFF
--- a/lib/geo_ip.php
+++ b/lib/geo_ip.php
@@ -50,7 +50,7 @@ class Geo_Ip {
 		$original_md5 = wp_remote_fopen(self::SOURCE_MD5_URL);
 		$our_md5      = md5_file(self::get_upload_file_path());
 
-		return $original_md5 == $our_md5;
+		return $original_md5 === $our_md5;
 	}
 
 	public static function get_upload_file_path()


### PR DESCRIPTION
GeoIp is using an unsafe string comparison to compare the hash value of the downloaded file with the md5 hash provided by the resource. In some cases this might result in accepting a broken download.
