### PR TITLE
Add {before,after}_widget data to widgets.

### DIFF
--- a/lib/modules/subscribe_button/widget.php
+++ b/lib/modules/subscribe_button/widget.php
@@ -16,6 +16,7 @@ class Widget extends \WP_Widget {
 
 	public function widget( $args, $instance ) {
 		?>
+		<?php echo $args['before_widget']; ?>
 		<aside id="<?php echo $args['widget_id']; ?>" class="widget">
 			
 			<?php if ( strlen($instance['title']) ): ?>
@@ -29,6 +30,7 @@ class Widget extends \WP_Widget {
 			<?php endif; ?>
 
 		</aside>
+		<?php echo $args['after_widget']; ?>
 		<?php
 	}
 


### PR DESCRIPTION
cf. http://codex.wordpress.org/Function_Reference/register_sidebar and e.g. http://wordpress.stackexchange.com/questions/18942/add-class-to-before-widget-from-within-a-custom-widget