### PR TITLE
Remove hardcoded <aside> Tag

### DIFF
--- a/lib/modules/subscribe_button/widget.php
+++ b/lib/modules/subscribe_button/widget.php
@@ -17,8 +17,7 @@ class Widget extends \WP_Widget {
 	public function widget( $args, $instance ) {
 		?>
 		<?php echo $args['before_widget']; ?>
-		<aside id="<?php echo $args['widget_id']; ?>" class="widget">
-			
+
 			<?php if ( strlen($instance['title']) ): ?>
 				<h3 class="widget-title"><?php echo $instance['title'] ?></h3>
 			<?php endif; ?>
@@ -29,7 +28,6 @@ class Widget extends \WP_Widget {
 				<p><?php echo $instance['infotext'] ?></p>
 			<?php endif; ?>
 
-		</aside>
 		<?php echo $args['after_widget']; ?>
 		<?php
 	}


### PR DESCRIPTION
A before_widget setting already contains an autogenerated id, e.g.:

```php
    'before_widget' => '<div class="sidebarbox" id="%1$s">',
```

Podlove should not just hardcode HTML into people’s sidebars.