### PR TITLE
implemented a slightly better handling of the episode's excerpt/summary

### DIFF
--- a/lib/podcast_post_type.php
+++ b/lib/podcast_post_type.php
@@ -238,9 +238,14 @@ class Podcast_Post_Type {
 
 	public function default_excerpt_to_episode_summary( $excerpt ) {
 		global $post;
-
-		$episode = \Podlove\Model\Episode::find_or_create_by_post_id( $post->ID );
-		return $episode && strlen( $episode->summary ) > 0 ? $episode->summary : $excerpt;
+    
+		if ( get_post_type() == 'podcast' ) {
+  		$episode = \Podlove\Model\Episode::find_or_create_by_post_id( $post->ID );
+      $excerpt = strlen( $episode->summary ) > 0 ? $episode->summary : $excerpt;
+      $filtered = apply_filters("wp_trim_excerpt", $excerpt);
+  		return $filtered;
+		}
+    else return $excerpt;
 	}
 
 	public function create_menu() {


### PR DESCRIPTION
Returning the excerpt or the summary at this point makes it impossible for WP themes to customize the excerpt through custom trimming or adding a custom "Read more" link after the text.

I propose the changes in the commit which limit the handling of the the excerpt from the used hook to posts of the type "podcast" and apply all the filters registered in Wordpress under the hook "wp_trim_excerpt" so themes can use this hook to further customize the text returned by Podlove Publisher.
