### PR TITLE
Old application system replaced

### DIFF
--- a/lib/modules/twitter_summary_card/twitter_summary_card.php
+++ b/lib/modules/twitter_summary_card/twitter_summary_card.php
@@ -7,7 +7,7 @@ use Podlove\DomDocumentFragment;
 class Twitter_Summary_Card extends \Podlove\Modules\Base {
 
 		protected $module_name = 'Twitter Card Integration';
-		protected $module_description = 'Adds Twitter summary card metadata to episodes. <a href="https://dev.twitter.com/form/participate-twitter-cards" target="_blank">Right now, you need to apply here to make it work.</a>';
+		protected $module_description = 'Adds Twitter summary card metadata to episodes. <a href="https://cards-dev.twitter.com/validator" target="_blank">Right now, you need to validate and whitelist your site to make it work.</a>';
 		protected $module_group = 'web publishing';
 
 		public function load() {


### PR DESCRIPTION
The old twitter cards whitelist application form was replaced by the card validator, where you can request your WP site to be whitelisted.