### PR TITLE
Fix case sensitive constant

### DIFF
--- a/lib/feed_discoverability.php
+++ b/lib/feed_discoverability.php
@@ -28,7 +28,7 @@ class FeedDiscoverability {
 			return;
 
 		if ( ! function_exists( '\Podlove\Feeds\prepare_for_feed' ) )
-			require_once \PODLOVE\PLUGIN_DIR . 'lib/feeds/base.php';
+			require_once \Podlove\PLUGIN_DIR . 'lib/feeds/base.php';
 
 		echo TemplateCache::get_instance()->cache_for('', function() {
 			$html = '';


### PR DESCRIPTION
Change \PODLOVE\PLUGIN_DIR constant to \Podlove\PLUGIN_DIR in lib/feed_discoverability.php to fix following error: Fatal error: Undefined constant 'PODLOVE\\PLUGIN_DIR'

This happens with Debian GNU/Linux 8.0 (jessie) (3.16.0-4-amd64) and HipHop VM 3.7.0