### PR TITLE
Vagrant dev env

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ test/config.yml
 bower_components
 doc
 .htaccess
+log/*
+.vagrant/*

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ php composer.phar --dev install
 
 ### Vagrant virtual machine
 
-For easy setup of a virtual machine for development including the latest WordPress release, Apache 2.4, PHP 5.6 and MySQL 5.6, a configuration file for
+For easy setup of a virtual machine for development including the latest WordPress release, Apache 2.4, PHP 5.5 and MySQL 5.6, a configuration file for
 Vagrant is included.
 
 Just run the following command in the root directory of your checkout:

--- a/README.md
+++ b/README.md
@@ -21,6 +21,22 @@ curl -sS https://getcomposer.org/installer | php
 php composer.phar --dev install
 ```
 
+
+### Vagrant virtual machine
+
+For easy setup of a virtual machine for development including the latest WordPress release, Apache 2.4, PHP 5.6 and MySQL 5.6, a configuration file for
+Vagrant is included.
+
+Just run the following command in the root directory of your checkout:
+
+```
+vagrant up
+```
+
+The provisioning script will take care of all the initial installation stuff. Then point your browser to `http://localhost:8080` for HTTP or
+`https://localhost:8443` for HTTPS. Database username and password is `root`. A database called `wordpress` is already created.
+
+
 ## Release Checklist
 
 - Ensure changelog in `readme.txt` has an entry for that version

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,92 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# windows friendly development
+use_smb = false
+
+Vagrant.configure(2) do |config|
+  config.vm.box = "debian/jessie64"
+
+  config.vm.network "forwarded_port", guest: 80, host: 8080
+  config.vm.network "forwarded_port", guest: 443, host: 8443
+
+  if use_smb
+    config.vm.synced_folder ".", "/vagrant", type: :smb
+  else
+    config.vm.synced_folder ".", "/vagrant", type: :nfs
+  end
+
+  config.vm.provision "shell", inline: <<-SHELL
+    debconf-set-selections <<< 'mysql-server mysql-server/root_password password root'
+    debconf-set-selections <<< 'mysql-server mysql-server/root_password_again password root'
+
+    sudo apt-get update
+    sudo apt-get install -y wget git
+    sudo apt-get install -y mysql-server mysql-client
+    sudo apt-get install -y apache2 php5 php5-mysql php5-gd php5-curl libapache2-mod-php5
+
+    sudo chown -R vagrant:vagrant /var/www
+    rm -rf /var/www/*
+    cd /var/www
+    wget https://de.wordpress.org/latest-de_DE.zip
+    unzip latest-de_DE.zip
+    rm latest-de_DE.zip
+
+    echo '<VirtualHost *:80>
+            DocumentRoot /var/www/wordpress
+
+            LogLevel warn
+
+            ErrorLog /vagrant/log/error.log
+            
+            <Directory /var/www/wordpress>
+              Options +Indexes +FollowSymlinks
+              AllowOverride all
+              Allow from all
+              Order allow,deny
+              Require all granted
+            </Directory>
+    </VirtualHost>
+
+    <VirtualHost *:443>
+            DocumentRoot /var/www/wordpress
+
+            LogLevel warn
+
+            ErrorLog /vagrant/log/error.log
+            
+            SSLEngine on
+            SSLCertificateFile /etc/ssl/certs/ssl-cert-snakeoil.pem
+            SSLCertificateKeyFile /etc/ssl/private/ssl-cert-snakeoil.key
+
+            <Directory /var/www/wordpress>
+              Options +Indexes +FollowSymlinks
+              AllowOverride all
+              Allow from all
+              Order allow,deny
+              Require all granted
+            </Directory>
+    </VirtualHost>' > /etc/apache2/sites-enabled/000-default.conf
+
+    mkdir /vagrant/log
+
+    sed -i -e 's/export APACHE_RUN_USER=www-data/export APACHE_RUN_USER=vagrant/' /etc/apache2/envvars
+    sed -i -e 's/export APACHE_RUN_GROUP=www-data/export APACHE_RUN_GROUP=vagrant/' /etc/apache2/envvars
+
+    chown -R vagrant:vagrant /var/www/wordpress
+
+    sudo make-ssl-cert generate-default-snakeoil --force-overwrite
+
+    sudo a2enmod ssl
+    sudo a2enmod rewrite
+    sudo service apache2 restart
+
+    mysql -u root -proot -e "create database wordpress"
+
+    ln -s /vagrant /var/www/wordpress/wp-content/plugins/podlove-podcasting-plugin-for-wordpress
+
+    cd /vagrant
+    curl -sS https://getcomposer.org/installer | php
+    php composer.phar --dev install
+  SHELL
+end


### PR DESCRIPTION
Added a Vagrantfile to simplify the setup of your dev box.

1. Install VirtualBox & Vagrant
2. Run "vagrant up" in your checkouts' root

Creates a Debian Jessie based virtual machine including Apache 2.4, PHP 5.5 and MySQL 5.5.
Syncs the plugin via NFS by default for development on OS X/BSD/Linux, but can be switched to SMB for windows development by changing `use_smb` to `true`.