### PR TITLE
fix: JavaScript event for secondary download button

### DIFF
--- a/js/frontend.js
+++ b/js/frontend.js
@@ -4,7 +4,7 @@ jQuery(function($) {
 		var $select = $("select", this),
 		    $that = this;
 
-		$("button.secondary", this).on("click", function(e) {
+		$("button.podlove-download-secondary", this).on("click", function(e) {
 			e.preventDefault();
 			prompt("Feel free to copy and paste this URL", $("option", $select).filter(":selected").data("raw-url"));
 			return false;

--- a/readme.txt
+++ b/readme.txt
@@ -111,6 +111,7 @@ This product includes GeoLite2 data created by MaxMind, available from http://ww
 = 2.3.2 =
 
 * fix: template call `episode.chapters` returns an empty list when there are no chapters
+* fix: JavaScript event for secondary download button
 
 = 2.3.1 =
 


### PR DESCRIPTION
Missed rename in JavaScript for change in 7cfb3bc
Restore `Show URL` button functionality