### PR TITLE
Refactor ChaptersManager

### DIFF
--- a/includes/chapters.php
+++ b/includes/chapters.php
@@ -3,7 +3,7 @@ use Podlove\Model;
 
 /**
  * Enable chapters pages
- * 
+ *
  * add ?chapters_format=psc|json|mp4chaps to any episode URL to get chapters
  */
 add_action( 'wp', function() {
@@ -11,8 +11,9 @@ add_action( 'wp', function() {
 	if ( ! is_single() )
 		return;
 
+	$chapters_format_regex = apply_filters( 'podlove_chapters_format_regex', "/^(psc|json|mp4chaps)$/" );
 	$chapters_format = filter_input(INPUT_GET, 'chapters_format', FILTER_VALIDATE_REGEXP, [
-		'options' => ['regexp' => "/^(psc|json|mp4chaps)$/"]
+		'options' => ['regexp' => $chapters_format_regex]
 	]);
 
 	if ( ! $chapters_format )
@@ -32,50 +33,17 @@ add_action( 'wp', function() {
 		case 'json':
 			header( "Content-Type: application/json" );
 			break;
-	}	
-	
+	}
+
+	do_action( 'podlove_chapter_page', $chapters_format, $episode );
+
 	echo $episode->get_chapters( $chapters_format );
+
 	exit;
 } );
 
-/**
- * When changing from an external chapter asset to 'manual', copy external 
- * contents into local field.
- */
-add_filter('pre_update_option_podlove_asset_assignment', function($new, $old) {
-	global $wpdb;
-
-	if (!isset($old['chapters']) || !isset($new['chapters']))
-		return $new;
-
-	if ($new['chapters'] != 'manual')  // just changes to manual
-		return $new;
-
-	if (((int) $old['chapters']) <= 0) // just changes from an asset
-		return $new;
-
-	$episodes = \Podlove\Model\Episode::find_all_by_time();
-
-	// 10 seconds per episode or 30 seconds since 1 request per asset 
-	// is required if it is not cached
-	set_time_limit(max(30, count($episodes) * 10));
-
-	foreach ($episodes as $episode) {
-		if ($chapters = $episode->get_chapters('mp4chaps'))
-			$episode->update_attribute('chapters', esc_sql($chapters));
-	}
-
-	// delete chapters caches
-	$wpdb->query('DELETE FROM `' . $wpdb->options . '` WHERE option_name LIKE "%podlove_chapters_string_%"');
-
-	return $new;
-}, 10, 2);
-
 // extend episode form
 add_filter('podlove_episode_form_data', function($form_data, $episode) {
-	
-	if ( Model\AssetAssignment::get_instance()->chapters !== 'manual' )
-		return $form_data;
 
 	$form_data[] = array(
 		'type' => 'text',

--- a/lib/chapters_manager.php
+++ b/lib/chapters_manager.php
@@ -4,6 +4,7 @@ namespace Podlove;
 use Podlove\Model;
 use Podlove\Chapters\Printer;
 use Podlove\Chapters\Parser;
+use Podlove\Chapters\Chapters;
 
 /**
  * Convenience wrapper for episode chapters.
@@ -11,10 +12,7 @@ use Podlove\Chapters\Parser;
  * Handles caching of chapters.
  */
 class ChaptersManager {
-
-	private $episode;
-	private $chapters_raw = '';
-	private $chapters_object = NULL;
+	public $episode;
 
 	public function __construct( Model\Episode $episode ) {
 		$this->episode = $episode;
@@ -22,106 +20,132 @@ class ChaptersManager {
 
 	/**
 	 * Get episode chapters.
-	 * 
+	 *
 	 * @param  string $format object, psc, mp4chaps, json. Default: object
 	 * @return mixed
 	 */
 	public function get( $format = 'object' ) {
-
-		if ( ! $this->chapters_object )
-			$this->chapters_object = $this->get_chapters_object();
-
-		if ( ! $this->chapters_object )
-			return '';
+		$chapters_object = $this->get_chapters_object();
+		$chapters = '';
 
 		switch ( $format ) {
 			case 'psc':
-				$this->chapters_object->setPrinter( new Printer\PSC() );
-				return (string) $this->chapters_object;
+				$chapters_object->setPrinter( new Printer\PSC() );
+				$chapters = (string) $chapters_object;
 				break;
+
 			case 'mp4chaps':
-				$this->chapters_object->setPrinter( new Printer\Mp4chaps() );
-				return (string) $this->chapters_object;
+				$chapters_object->setPrinter( new Printer\Mp4chaps() );
+				$chapters = (string) $chapters_object;
 				break;
+
 			case 'json':
-				$this->chapters_object->setPrinter( new Printer\JSON() );
-				return (string) $this->chapters_object;
+				$chapters_object->setPrinter( new Printer\JSON() );
+				$chapters = (string) $chapters_object;
+				break;
+
+			case 'object':
+				$chapters = $chapters_object;
 				break;
 		}
 
-		return $this->chapters_object;
+		return apply_filters( 'podlove_get_chapters', $chapters, $format, $chapters_object );
 	}
 
-	private function get_raw_chapters_string() {
-		$asset_assignment = Model\AssetAssignment::get_instance();
+	protected function get_raw_chapters_string($chapters_file) {
 		$cache_key = 'podlove_chapters_string_' . $this->episode->id;
-		if ( ( $chapters_string = get_transient( $cache_key ) ) !== FALSE ) {
-			return $chapters_string;
-		} else {
-			if ( $asset_assignment->chapters == 'manual' ) {
-				return $this->episode->chapters;
-			} else {
-				if ( ! $chapters_asset = Model\EpisodeAsset::find_one_by_id( $asset_assignment->chapters ) )
-					return '';
 
-				if ( ! $chapters_file = Model\MediaFile::find_by_episode_id_and_episode_asset_id( $this->episode->id, $chapters_asset->id ) )
-					return '';
+		if ( false === ( $chapters_string = get_transient( $cache_key ) ) ) {
+			$request = wp_remote_get( $chapters_file->get_file_url() );
 
-				$chapters_string = wp_remote_get( $chapters_file->get_file_url() );
+			if ( is_wp_error( $request ) )
+				return '';
 
-				if ( is_wp_error( $chapters_string ) )
-					return '';
+			// 1 year, we devalidate manually
+			$chapters_string = $request['body'];
+			set_transient( $cache_key, $chapters_string, 60*60*24*365 );
+		}
 
-				set_transient( $cache_key, $chapters_string['body'], 60*60*24*365 ); // 1 year, we devalidate manually
-				return $chapters_string['body'];
-			}
-		}	
-
+		return $chapters_string;
 	}
 
 	private function get_chapters_object() {
+		global $wpdb;
 
-		if ( ! $this->chapters_raw )
-			$this->chapters_raw = $this->get_raw_chapters_string();
+		// Get all posible assets with a chapter file format
+		$chapter_assets = Model\EpisodeAsset::find_all_by_sql(
+			"SELECT ea.*, ft.mime_type
+			 FROM {$wpdb->prefix}podlove_episodeasset AS ea
+			 INNER JOIN {$wpdb->prefix}podlove_filetype AS ft ON ft.id = ea.file_type_id
+			 WHERE ft.type = 'chapters'
+			 ORDER BY position ASC"
+		);
 
-		if ( ! $this->chapters_raw )
-			return NULL;
-
-		$asset_assignment = Model\AssetAssignment::get_instance();
-
-		if ( $asset_assignment->chapters == 'manual' )
-			return Parser\Mp4chaps::parse( $this->chapters_raw );
-
-		if ( ! $chapters_asset = Model\EpisodeAsset::find_one_by_id( $asset_assignment->chapters ) )
-			return NULL;
-
-		$mime_type = $chapters_asset->file_type()->mime_type;
-		$chapters  = false;
-
-		switch ( $mime_type ) {
-			case 'application/xml':
-				$chapters = Parser\PSC::parse( $this->chapters_raw );
-				break;
-			case 'application/json':
-				$chapters = Parser\JSON::parse( $this->chapters_raw );
-				break;
-			case 'text/plain':
-				switch ( $this->chapters_raw[0] ) {
-					case '[':
-					case '{':
-						$chapters = Parser\JSON::parse( $this->chapters_raw );
-						break;
-					case '<':
-						$chapters = Parser\PSC::parse( $this->chapters_raw );
-						break;
-					default:
-						$chapters = Parser\Mp4chaps::parse( $this->chapters_raw );
-						break;
-				}
-				break;
+		// Get IDs
+		$chapter_assets_id_to_mimetype = array();
+		foreach ( $chapter_assets as $chapter_asset ) {
+			$chapter_assets_id_to_mimetype[$chapter_asset->id] = $chapter_asset->mime_type;
 		}
 
-		return $chapters;
-	}
+		// Try to find attached chapter file to this episode
+		$chapter_assets_ids = implode( ',', array_keys( $chapter_assets_id_to_mimetype ) );
+		$chapters_file = Model\MediaFile::find_one_by_where( sprintf(
+			"episode_id = %d
+			 AND episode_asset_id IN (%s)
+			 ORDER BY FIELD(episode_asset_id, %s)",
+			$this->episode->id, $chapter_assets_ids, $chapter_assets_ids
+		) );
 
+		// Fallback to manual entry if no file was attached
+		if ( null === $chapters_file )
+			return Parser\Mp4chaps::parse( $this->episode->chapters );
+
+		// Get mimetype for attached chapter file
+		$mime_type = $chapter_assets_id_to_mimetype[$chapters_file->episode_asset_id];
+
+		// Get chapters object for mine type
+		switch ( $mime_type ) {
+			case 'application/xml':
+				$contents = $this->get_raw_chapters_string( $chapters_file );
+				$chapters = Parser\PSC::parse( $contents );
+
+				break;
+
+			case 'application/json':
+				$contents = $this->get_raw_chapters_string( $chapters_file );
+				$chapters = Parser\JSON::parse( $contents );
+
+				break;
+
+			case 'text/plain':
+				$contents = $this->get_raw_chapters_string( $chapters_file );
+
+				switch ( $contents[0] ) {
+					case '[':
+					case '{':
+						$chapters = Parser\JSON::parse( $contents );
+						break;
+					case '<':
+						$chapters = Parser\PSC::parse( $contents );
+						break;
+					default:
+						$chapters = Parser\Mp4chaps::parse( $contents );
+						break;
+				}
+
+				break;
+
+			default:
+				$chapters = '';
+		}
+
+		// Apply filter
+		return apply_filters(
+			'podlove_get_chapters_object',
+			( '' === $chapters || null === $chapters ) ? new Chapters : $chapters,
+			$mime_type,
+			$chapters_file,
+			$this
+		);
+	}
 }

--- a/lib/model/asset_assignment.php
+++ b/lib/model/asset_assignment.php
@@ -30,7 +30,7 @@ class AssetAssignment {
 	}
 
 	final private function __clone() { }
-	
+
 	public function __set( $name, $value ) {
 		if ( $this->has_property( $name ) ) {
 			$this->set_property( $name, $value );
@@ -38,11 +38,11 @@ class AssetAssignment {
 			$this->$name = $value;
 		}
 	}
-	
+
 	private function set_property( $name, $value ) {
 		$this->data[ $name ] = $value;
 	}
-	
+
 	public function __get( $name ) {
 		if ( $this->has_property( $name ) ) {
 			return $this->get_property( $name );
@@ -50,7 +50,7 @@ class AssetAssignment {
 			return $this->$name;
 		}
 	}
-	
+
 	private function get_property( $name ) {
 		if ( isset( $this->data[ $name ] ) ) {
 			return $this->data[ $name ];
@@ -61,30 +61,30 @@ class AssetAssignment {
 
 	/**
 	 * Return a list of property dictionaries.
-	 * 
+	 *
 	 * @return array property list
 	 */
 	private function properties() {
-		
+
 		if ( ! isset( self::$properties ) )
 			self::$properties = [];
-		
+
 		return self::$properties;
 	}
-	
+
 	/**
 	 * Does the given property exist?
-	 * 
+	 *
 	 * @param string $name name of the property to test
 	 * @return bool True if the property exists, else false.
 	 */
 	public function has_property( $name ) {
 		return in_array( $name, $this->property_names() );
 	}
-	
+
 	/**
 	 * Return a list of property names.
-	 * 
+	 *
 	 * @return array property names
 	 */
 	public function property_names() {
@@ -93,7 +93,7 @@ class AssetAssignment {
 
 	/**
 	 * Define a property with by name.
-	 * 
+	 *
 	 * @param string $name Name of the property / column
 	 */
 	public static function property( $name ) {
@@ -120,20 +120,19 @@ class AssetAssignment {
 
 	/**
 	 * Generate a human readable title.
-	 * 
+	 *
 	 * Return name and, if available, the subtitle. Separated by a dash.
-	 * 
+	 *
 	 * @return string
 	 */
 	public function full_title() {
 		$t = $this->title;
-		
+
 		if ( $this->subtitle )
 			$t = $t . ' - ' . $this->subtitle;
-		
+
 		return $t;
 	}
 }
 
 AssetAssignment::property( 'image' );
-AssetAssignment::property( 'chapters' );

--- a/lib/model/episode_asset.php
+++ b/lib/model/episode_asset.php
@@ -16,7 +16,7 @@ class EpisodeAsset extends Base {
 		}
 
 		parent::save();
-		
+
 		$this->maybe_connect_to_web_player();
 	}
 
@@ -33,7 +33,7 @@ class EpisodeAsset extends Base {
 
 	/**
 	 * Find all media file models in this location.
-	 * 
+	 *
 	 * @return array|NULL
 	 */
 	function media_files() {
@@ -66,7 +66,7 @@ class EpisodeAsset extends Base {
 
 	/**
 	 * Checks if asset is used by web player.
-	 * 
+	 *
 	 * @return boolean true if connected to any web player asset, otherwise false.
 	 */
 	public function is_connected_to_web_player() {
@@ -91,7 +91,7 @@ class EpisodeAsset extends Base {
 		if ( isset( $allowed_formats[ $type ] ) ) {
 			foreach ( $allowed_formats[ $type ] as $extension => $format_data ) {
 				if ( in_array($asset_type, $format_data['mime_types']) ) {
-					
+
 					if ( ! isset( $webplayer_formats[ $type ] ) )
 						$webplayer_formats[ $type ] = array();
 
@@ -108,7 +108,7 @@ class EpisodeAsset extends Base {
 
 	/**
 	 * Checks if asset is connected to any feed.
-	 * 
+	 *
 	 * @return boolean true if connected to any feed, otherwise false.
 	 */
 	public function is_connected_to_feed() {
@@ -119,7 +119,7 @@ class EpisodeAsset extends Base {
 	 * Checks if asset has an active media file.
 	 *
 	 * A media file is active if its file size is > 0.
-	 * 
+	 *
 	 * @return boolean true if any media file has a size > 0, otherwise false.
 	 */
 	public function has_active_media_files() {
@@ -128,12 +128,12 @@ class EpisodeAsset extends Base {
 
 	/**
 	 * Checks if asset is assigned as image or chapter asset.
-	 * 
+	 *
 	 * @return boolean true if assigned, otherwise false.
 	 */
 	public function has_asset_assignments() {
 		$assignment = AssetAssignment::get_instance();
-		return in_array( $this->id, array( $assignment->image, $assignment->chapters ) );
+		return in_array( $this->id, array( $assignment->image ) );
 	}
 
 	/**
@@ -144,7 +144,7 @@ class EpisodeAsset extends Base {
 	 * - has no asset assignment
 	 * - is not connected to any feed
 	 * - is not connected to web player
-	 * 
+	 *
 	 * @return boolean true if it should be deleted, otherwise false.
 	 */
 	public function is_deletable() {


### PR DESCRIPTION
The current implentation of ChaptersManager was not flexible for new types of chapters. Also it hadn't allowed the use of different chapter formats (file or manual) at the same time. This PR tries to fix that.
- Introducing filters and actions to allow adding new chapter file formats
- Use the chapter field on the episode (manual mode) now as fallback
- Checks if episode has one at least one chapter file and uses the prioritized format
- The order for prioritization of formats is the same as the asset display order currently

Example for a new chapter file format: https://github.com/gglnx/hindenburg-chapters
