### PR TITLE
Prepare podlove webplayer configuration for internationalization

### DIFF
--- a/lib/modules/podlove_web_player/player_v3/player_config.php
+++ b/lib/modules/podlove_web_player/player_v3/player_config.php
@@ -80,7 +80,8 @@ class PlayerConfig {
             "downloads" => $downloads,
             "duration" => $this->episode->get_duration(),
             "features" => ["current", "progress", "duration", "tracks", "fullscreen", "volume"],
-            "chapters" => json_decode($this->episode->get_chapters('json'))
+            "chapters" => json_decode($this->episode->get_chapters('json')),
+            "languageCode" => $this->podcast->language
          ];
 
          return $config;


### PR DESCRIPTION
This makes the webplayer 3 configuration ready for internationalization. Tested with `multilingual` branch of podlove-web-player.