### PR TITLE
updated deprecated post_permalink() to newer get_permalink()

### DIFF
--- a/lib/modules/widgets/widgets/recent_episodes.php
+++ b/lib/modules/widgets/widgets/recent_episodes.php
@@ -36,7 +36,7 @@ class RecentEpisodes extends \WP_Widget {
 					<div style="display: inline-block; width: 75%;">
 					<?php endif; ?>
 					<p>
-						<a href="<?php echo post_permalink($episode->post_id); ?>"><?php echo $post->post_title; ?></a><br />
+						<a href="<?php echo get_permalink($episode->post_id); ?>"><?php echo $post->post_title; ?></a><br />
 						<i class="podlove-icon-calendar"></i> <?php echo get_the_date( get_option('date_format'), $episode->post_id ); ?>
 						<?php 
 						if ($instance[ 'show_duration' ])


### PR DESCRIPTION
`post_permalink()` appears deprecated and might cause a Wordpress-notice within the `<a>`-Tag:
```HTML
<a href="<br />
<b>Notice</b>:  post_permalink ist seit Version 4.4.0 <strong>veraltet</strong>!
[…]
>
```

https://developer.wordpress.org/reference/functions/post_permalink/