### PR TITLE
Added a description field to contributors

### DIFF
--- a/lib/modules/contributors/model/contributor.php
+++ b/lib/modules/contributors/model/contributor.php
@@ -331,3 +331,4 @@ Contributor::property( 'publicname', 'TEXT' );
 Contributor::property( 'visibility', 'TINYINT(1)' );
 Contributor::property( 'guid', 'TEXT' );
 Contributor::property( 'contributioncount', 'INT' );
+Contributor::property( 'description', 'TEXT' );

--- a/lib/modules/contributors/settings/tab/contributors.php
+++ b/lib/modules/contributors/settings/tab/contributors.php
@@ -102,8 +102,16 @@ class Contributors extends Tab {
 					'description' => 'Either a Gravatar email adress or a URL.',
 					'html'        => array( 'class' => 'podlove-contributor-field podlove-check-input', 'data-podlove-input-type' => 'avatar' )
 				)
-			], 
-			'slug' => [
+			],
+            'description' => [
+                'field_type' => 'string',
+                'field_options' => array(
+                    'label'       => __( 'Description', 'podlove-podcasting-plugin-for-wordpress' ),
+                    'description' => 'The description can be used for storing a default description of the contributor.',
+                    'html'        => array( 'class' => 'podlove-check-input podlove-contributor-field', 'data-podlove-input-type' => 'description' )
+                )
+            ],
+            'slug' => [
 				'field_type' => 'string',
 				'field_options' => array(
 					'label'       => __( 'ID', 'podlove-podcasting-plugin-for-wordpress' ),


### PR DESCRIPTION
The comment field can be useful, but is burdensome if there is the desire to have the same text associated with a contributor for every episode. Adding a description field allows for that text to be permanently associated with the contributor for purpose of inclusion in a template