### PR TITLE
Optimizing Network (Multisite) System Report

### DIFF
--- a/lib/modules/networks/networks.php
+++ b/lib/modules/networks/networks.php
@@ -40,14 +40,14 @@ class Networks extends \Podlove\Modules\Base {
 
 	public function add_system_report_validations($fields)
 	{
-		$fields['network module'] = [
+		$fields['multisite'] = [
 			'callback' => function() {
 				if (self::is_active_in_main_blog()) {
 					return "ok";
 				} else {
 					return [
-						"message" => __( "Must be active in main blog!", 'podlove-podcasting-plugin-for-wordpress' ),
-						"error" => __( "You are using the network module. You have to activate it in your main WordPress blog to work properly", 'podlove-podcasting-plugin-for-wordpress' )
+						"message" => __( "Podlove Publisher is not activated in main blog!", 'podlove-podcasting-plugin-for-wordpress' ),
+						"notice" => __( "If you want to use Podcast network functionality you have to activate the Podlove Plugin in your main WordPress blog to work properly" , 'podlove-podcasting-plugin-for-wordpress' )
 					];
 				}
 			}
@@ -60,10 +60,9 @@ class Networks extends \Podlove\Modules\Base {
 		global $current_site;
 
 		return \Podlove\with_blog_scope($current_site->blog_id, function() {
-			$module_active = \Podlove\Modules\Base::is_active('networks');
 			$plugin_active = is_plugin_active( plugin_basename( \Podlove\PLUGIN_FILE ) );
 			
-			return $module_active && $plugin_active;
+			return $plugin_active;
 		});
 	}
 

--- a/lib/settings/support.php
+++ b/lib/settings/support.php
@@ -68,9 +68,8 @@ class Support {
 					</li>
 					<li>
 						<?php echo sprintf(
-							__('For quick remarks and feedback, you can reach us at %sTwitter (@podlove_org)%s and %sADN (@podlove)%s', 'podlove-podcasting-plugin-for-wordpress'),
-							'<a target="_blank" href="//twitter.com/podlove_org">', '</a>',
-							'<a target="_blank" href="https://alpha.app.net/podlove">', '</a>'
+							__('For quick remarks and feedback, you can reach us at %sTwitter (@podlove_org)%s', 'podlove-podcasting-plugin-for-wordpress'),
+							'<a target="_blank" href="//twitter.com/podlove_org">', '</a>'
 						); ?>
 					</li>
 				</ul>

--- a/lib/system_report.php
+++ b/lib/system_report.php
@@ -236,8 +236,8 @@ class SystemReport {
 
 		$out .= "\n";
 
-		if ( count( $this->errors ) ) {
-			$out .= _n( '1 ERROR', '%s ERRORS', count( $this->errors ), 'podlove' );
+		if ( $number_of_errors = count( $this->errors ) ) {
+			$out .= sprintf( _n( '%s ERROR', '%s ERRORS', $number_of_errors, 'podlove' ), $number_of_errors );
 			$out .= ": \n";
 			foreach ( $this->errors as $error ) {
 				$out .= "- $error\n";
@@ -246,8 +246,8 @@ class SystemReport {
 			$out .= "0 errors\n";
 		}
 
-		if ( count( $this->notices ) ) {
-			$out .= _n( '1 NOTICE', '%s NOTICES', count( $this->notices ), 'podlove' );
+		if ( $number_of_notices = count( $this->notices ) ) {
+			$out .= sprintf( _n( '%s NOTICE', '%s NOTICES', $number_of_notices, 'podlove' ), $number_of_notices );
 			$out .= " (no dealbreaker, but should be fixed if possible): \n";
 			foreach ( $this->notices as $error ) {
 				$out .= "- $error\n";


### PR DESCRIPTION
* Changed the system report messages for multisite environments to match the current plugin infrastructure
* Changed the checks performed to determine issues with the network environment
* Instead of an error a notice is displayed in the system report if the Publisher is not active in the main WP blog
* Fixes a bug that showed the placeholder (%s) instead of the number of errors/notices in the system report