### PR TITLE
Add i18n Support to Twig templates

### DIFF
--- a/lib/template/twig_filter.php
+++ b/lib/template/twig_filter.php
@@ -89,6 +89,10 @@ class TwigFilter {
 		$func = new \Twig_SimpleFunction('shortcode_exists', function($shortcode) { return \shortcode_exists($shortcode); });
 		$twig->addFunction($func);
 
+		// __() for Twig (Used for i18n)
+		$func = new \Twig_SimpleFunction('__', function($string) { return __($string, 'podlove-podcasting-plugin-for-wordpress'); });
+		$twig->addFunction($func);
+
 		$context = ['option' => $vars];
 
 		// add podcast to global context

--- a/templates/license.twig
+++ b/templates/license.twig
@@ -18,16 +18,16 @@
 		<div class="podlove_cc_license">
 			<img src="{{ license.imageUrl }}" alt="License" />
 			<p>
-				This work is licensed under a <a rel="license" href="{{ license.url }}">{{ license.name }}</a>
+				{{ __('This work is licensed under a') }} <a rel="license" href="{{ license.url }}">{{ license.name }}</a>
 			</p>
 		</div>
 	{% else %}
-	    This work is licensed under the <a href="{{ license.url }}">{{ license.name }}</a> license.
+	    {{ __('This work is licensed under the') }} <a href="{{ license.url }}">{{ license.name }}</a> license.
 	{% endif %}
 {% else %}
     <div class="podlove_license">
 		<p style="color: red;">
-			This work is (not yet) licensed, as no license was chosen.
+			{{ __('This work is (not yet) licensed, as no license was chosen.') }}
 		</p>
     </div>
 {% endif %}

--- a/templates/shortcode/downloads-select.twig
+++ b/templates/shortcode/downloads-select.twig
@@ -13,8 +13,8 @@
         {% endif %}
     {% endfor %}
     </select>
-    <button class="podlove-download-primary">Download</button>
-    <button class="podlove-download-secondary">Show URL</button>
+    <button class="podlove-download-primary">{{ __('Download') }}</button>
+    <button class="podlove-download-secondary">{{ __('Show URL') }}</button>
  </div>
 </form>
 {% endspaceless %}

--- a/templates/shortcode/episode-list.twig
+++ b/templates/shortcode/episode-list.twig
@@ -1,9 +1,9 @@
 <table>
     <thead>
         <th></th>
-        <th>Date</th>
-        <th>Title</th>
-        <th>Duration</th>
+        <th>{{ __('Date') }}</th>
+        <th>{{ __('Title') }}</th>
+        <th>{{ __('Duration') }}</th>
     </thead>
     <tbody>
     {% for episode in podcast.episodes %}

--- a/templates/shortcode/feed-list.twig
+++ b/templates/shortcode/feed-list.twig
@@ -1,8 +1,8 @@
 <table>
 	<thead>
     	<tr>
-            <th>Feed</th>
-        	<th>Enclosure</th>
+            <th>{{ __('Feed') }}</th>
+        	<th>{{ __('Enclosure') }}</th>
         </tr>
     </thead>
     <tbody>


### PR DESCRIPTION
Implements the __() function from WordPress to Twig templates.

Unfortunately it can be expected that those strings will not be discoverable for translate.wordpress.org. However, it should be possible to add those strings to translate.wordpress.org using a dummy method as shown here: https://gist.github.com/chemiker/9a298a577c840b480d9f01a284ecaf1d. This method is never called but contains multiple calls of the __() WP function. Thus is can be expected that translate.wordpress.org discovers those strings. Not a nice method but it should do the job ;)