### PR TITLE
Shows Module

### DIFF
--- a/lib/feeds/rss.php
+++ b/lib/feeds/rss.php
@@ -53,7 +53,7 @@ class RSS {
 
 		override_feed_title( $feed );
 		override_feed_description( $feed );
-		override_feed_language( $feed );
+		override_feed_language( $feed ); // Is this actually doing something?
 		override_feed_head( 'rss2_head', $podcast, $feed, $file_type );
 		override_feed_entry( 'rss2_item', $podcast, $feed, $file_type );
 
@@ -96,7 +96,7 @@ class RSS {
 				echo "\n\t" . sprintf( '<atom:link rel="last" href="%s" />', $feed_url_for_page($wp_query->max_num_pages) );
 
 			if ( $podcast->language )
-				echo "\n\t" . '<language>' . $podcast->language . '</language>';
+				echo "\n\t" . '<language>' . apply_filters( 'podlove_feed_language', $podcast->language ) . '</language>';
 
 			do_action( 'podlove_rss2_head', $feed );
 
@@ -133,7 +133,7 @@ class RSS {
 			$page = get_query_var( 'paged' ) ? (int) get_query_var( 'paged' ) : 1;
 
 			$max = $feed->get_post_limit_sql();
-			$start = $max * ($page - 1);
+			$start = (int)$max * ( (int)$page - 1 );
 
 			if ($max > 0) {
 				return 'LIMIT ' . $start . ', ' . $max;

--- a/lib/modules/shows/js/admin.js
+++ b/lib/modules/shows/js/admin.js
@@ -1,0 +1,32 @@
+jQuery(document).ready(function($) {
+
+	/*
+	 * Creates a Show feed preview based on a generic Podcast feed
+	 */
+	var $update_feed_preview = function () {
+		$url_preview = $("#feed_subscribe_url_preview");
+		$show_slug = $("#podlove_show_slug").val();
+		
+		if ( $show_slug !== '' ) {
+			$slug_preview_url = $url_preview.data('show-preview-string') + ' ' +
+				$url_preview.data('show-feed-base-url') + '/show/' +
+				$show_slug + '/feed/' +
+				$url_preview.data('show-feed-slug');
+		} else {
+			$slug_preview_url = '';
+		}
+		
+		$url_preview.text($slug_preview_url);
+	}
+
+	$update_feed_preview();
+
+	$("#podlove_show_slug").on( 'keyup', function () {
+		$update_feed_preview();
+	} );
+
+});
+
+
+
+

--- a/lib/modules/shows/model/show.php
+++ b/lib/modules/shows/model/show.php
@@ -1,0 +1,138 @@
+<?php 
+namespace Podlove\Modules\Shows\Model;
+use \Podlove\Model\Image;
+use \Podlove\Model\Episode;
+
+class Show {
+
+	/**
+	 * A show object consists of the following properties:
+	 * 	- Title/Name
+	 * 	- Subtitle*
+	 * 	- Slug
+	 * 	- Description
+	 * 	- Image*
+	 * 	- Language*
+	 * 
+	 * Properties marked with * are meta
+	 */	
+	public function __construct() {
+		$this->id = false;
+		$this->title = '';
+		$this->subtitle = '';
+		$this->slug = '';
+		$this->summary = '';
+		$this->image = '';
+		$this->language = '';
+	}
+
+	/*
+	 * Searches all Show terms and returns all values matching $property == $value
+	 * 
+	 * @param string $property
+	 * @param string $value
+	 * 
+	 * @return array
+	 */
+	public static function find_all_terms_by_property($property = false, $value = false) {
+		$existing_properties =  [ 'title', 'description', 'slug', 'id' ];
+		$existing_meta_properties = ['image', 'language', 'subtitle'];
+		$search_parameters = array(
+				'taxonomy' => 'shows',
+				'hide_empty' => false
+			);
+
+		if ( in_array($property, $existing_meta_properties) ) {
+			$search_parameters['meta_key'] = $property;
+			$search_parameters['meta_value'] = $value;
+		}
+
+		if ( in_array($property, $existing_properties) ) {
+			switch ($property) {
+				case 'id':
+					$search_parameters['term_id'] = $value;
+				break;
+				case 'title':
+					$search_parameters['name'] = $value;
+				break;
+				case 'description':
+					$search_parameters['description__like'] = $value;
+				break;
+				default:
+					$search_parameters[$property] = $value;
+				break;
+			}
+		}
+
+		return self::format_terms( get_terms($search_parameters) );
+	}
+
+	public static function find_one_term_by_property($property = false, $value = false) {
+		$terms = self::find_all_terms_by_property($property, $value);
+
+		if ( is_array($terms) ) {
+			return $terms[0]; // returns first element only
+		} else {
+			return;
+		}
+	}
+
+	public static function find_by_id($id) {
+		return self::find_one_term_by_property('id', $id);
+	}
+
+	public static function find_one_by_episode_id($episode_id) {
+		$episode = Episode::find_by_id($episode_id);
+		
+		return self::find_one_by_post_id($episode->post_id);
+	}
+
+	public static function find_one_by_post_id($post_id) {
+		$postterms = get_the_terms( $post_id, 'shows' );
+		
+		return ( isset($postterms[0]) ? self::find_by_id($postterms[0]->term_id) : false );
+	}
+
+	public static function all() {
+		return self::find_all_terms_by_property();
+	}
+
+	/*
+	 * Returns terms as a well-defined object including all meta data.
+	 * 
+	 * @param mixed $terms Term(s) to be formated
+	 * 
+	 * @return mixed Returns an array if an array or object based on the type of $terms
+	 */
+	public static function format_terms($terms) {
+		$format_terms = function($term) {
+			$term_object = new Show;
+			$term_object->id = $term->term_id;
+			$term_object->title = $term->name;
+			$term_object->subtitle = get_term_meta( $term->term_id, 'subtitle', true );
+			$term_object->slug = $term->slug;
+			$term_object->summary = $term->description;
+			$term_object->image = get_term_meta( $term->term_id, 'image', true );
+			$term_object->language = get_term_meta( $term->term_id, 'language', true );
+
+			return $term_object;
+		};
+
+		if ( ! is_array($terms) ) {
+			return $format_terms($terms);
+		} else {
+			$formated_terms = [];
+
+			foreach ($terms as $term) {
+				$formated_terms[] = $format_terms($term);
+			}
+
+			return $formated_terms;
+		}
+	}
+
+	public function image() {
+		return new Image($this->image, $this->title);
+	}
+
+}

--- a/lib/modules/shows/settings/help/settings.php
+++ b/lib/modules/shows/settings/help/settings.php
@@ -1,0 +1,20 @@
+<?php
+return [
+	'podlove_help_shows' => [
+		'title'   => __('Shows', 'podlove-podcasting-plugin-for-wordpress'),
+		'content' => 
+			'<p>
+				'.__(
+					'Please find information on Podcast Networks in the <a href="http://docs.podlove.org/podlove-publisher/guides/podcast-network.html">Podlove Publisher Documentation</a>.', // @todo: Add a good description on the differences between shows and networks.
+					'podlove-podcasting-plugin-for-wordpress'
+				).'
+			</p>'
+	],
+	'podlove_help_shows_slug' => [
+		'title'   => __('Show Slug', 'podlove-podcasting-plugin-for-wordpress'),
+		'content' => 
+			'<p>
+				'.__('The slug is used to create unique feeds for each show. Please consider the URL preview to see how the slug is used to create show-specific feeds. An overview over all show specific feeds is available on the <a href="?page=podlove_shows_settings">Show landing page</a>.', 'podlove-podcasting-plugin-for-wordpress').'
+			</p>'
+	]
+];

--- a/lib/modules/shows/settings/settings.php
+++ b/lib/modules/shows/settings/settings.php
@@ -1,0 +1,275 @@
+<?php 
+namespace Podlove\Modules\Shows\Settings;
+
+use \Podlove\Modules\Shows\Model\Show;
+
+class Settings {
+
+	use \Podlove\HasPageDocumentationTrait;
+
+	const MENU_SLUG = 'podlove_shows_settings';
+	const SHOW_META_DATA = [ 'subtitle', 'language', 'image' ];
+
+	public function __construct($handle) {
+		$pagehook = add_submenu_page(
+			/* $parent_slug*/ $handle,
+			/* $page_title */ __('Shows', 'podlove-podcasting-plugin-for-wordpress'),
+			/* $menu_title */ __('Shows', 'podlove-podcasting-plugin-for-wordpress'),
+			/* $capability */ 'administrator',
+			/* $menu_slug  */ self::MENU_SLUG,
+			/* $function   */ [$this, 'page']
+		);
+
+		$this->init_page_documentation($pagehook);
+
+		add_action( 'admin_init', array( $this, 'process_form' ) );
+		add_action( "load-" . $pagehook, [$this, 'add_screen_options'] );
+	}
+
+	public function add_screen_options() {
+		add_screen_option( 'per_page', array(
+		   'label'   => __('Shows', 'podlove-podcasting-plugin-for-wordpress'),
+		   'default' => 10,
+		   'option'  => 'podlove_shows_per_page'
+		) );
+
+		$this->table = new ShowListTable;
+	}
+
+	public function process_form() {
+		if ( ! isset( $_REQUEST['show'] ) )
+			return;
+
+		$action = ( isset( $_REQUEST['action'] ) ) ? $_REQUEST['action'] : NULL;
+		
+		if ( $action === 'save' ) {
+			$this->save();
+		} elseif ( $action === 'create' ) {
+			$this->create();
+		} elseif ( $action === 'delete' ) {
+			$this->delete();
+		}
+	}
+
+	/**
+	 * Helper method: redirect to a certain page.
+	 */
+	private function redirect( $action, $episode_asset_id = NULL, $params = [] ) {
+		$page    = 'admin.php?page=' . self::MENU_SLUG;
+		$show    = ( $episode_asset_id ) ? '&show=' . $episode_asset_id : '';
+		$action  = '&action=' . $action;
+
+		array_walk( $params, function(&$value, $key) { $value = "&$key=$value"; } );
+		
+		wp_redirect( admin_url( $page . $show . $action . implode( '', $params ) ) );
+		exit;
+	}
+
+	/**
+	 * Process form: save/update a show
+	 */
+	private function save() {
+
+		if ( ! isset( $_REQUEST['show'] ) )
+			return;
+
+		$updated_term = wp_update_term(
+				$_REQUEST['show'],
+				'shows',
+				array(
+						'name' => $_POST['podlove_show']['title'],
+						'description' => $_POST['podlove_show']['summary'],
+						'slug' => $_POST['podlove_show']['slug']
+					)
+			);
+
+		// Add meta entries
+		if ( is_wp_error($updated_term) )
+			return;
+
+		foreach (self::SHOW_META_DATA as $meta_data) {
+			update_term_meta($_REQUEST['show'], $meta_data, $_POST['podlove_show'][$meta_data]);
+		}
+		
+		if (isset($_POST['submit_and_stay'])) {
+			$this->redirect( 'edit', $_REQUEST['show'] );
+		} else {
+			$this->redirect( 'index', $_REQUEST['show'] );
+		}
+	}
+	
+	/**
+	 * Process form: create a show
+	 */
+	private function create() {
+		global $wpdb;
+
+		if ( ! $_POST['podlove_show'] )
+			return;
+
+		$show = new Show;
+
+		// Create new term
+		$new_term = wp_insert_term(
+				$_POST['podlove_show']['title'],
+				'shows',
+				array(
+						'description' => $_POST['podlove_show']['summary'],
+						'slug' => $_POST['podlove_show']['slug']
+					)
+			);
+
+		// Add meta entries
+		if ( is_wp_error($new_term) )
+			return;
+
+		foreach (self::SHOW_META_DATA as $meta_data) {
+			add_term_meta($new_term['term_id'], $meta_data, $_POST['podlove_show'][$meta_data]);
+		}
+
+		if ( isset($_POST['submit_and_stay']) ) {
+			$this->redirect( 'edit', $new_term['term_id'] );
+		} else {
+			$this->redirect( 'index' );
+		}
+	}
+	
+	/**
+	 * Process form: delete a format
+	 */
+	private function delete() {
+		if (!isset($_REQUEST['show']))
+			return;
+
+		foreach (self::SHOW_META_DATA as $meta_data) {
+			delete_term_meta($_REQUEST['show'], $meta_data);
+		}
+
+		wp_delete_term($_REQUEST['show'], 'shows');
+
+		$this->redirect('index');
+	}
+
+	public function page() {
+		?>
+		<div class="wrap">
+			<?php screen_icon( 'podlove-podcast' ); ?>
+			<h2><?php echo __( 'Shows', 'podlove' ); ?><a href="#" data-podlove-help="podlove_help_shows"><sup>?</sup></a> <a href="?page=<?php echo self::MENU_SLUG; ?>&amp;action=new" class="add-new-h2"><?php echo __( 'Add New', 'podlove-podcasting-plugin-for-wordpress' ); ?></a></h2>
+
+			<?php 
+				if ( isset($_GET["action"]) && $_GET["action"] == 'confirm_delete' ) :
+					$show = Show::find_by_id( $_REQUEST['show'] );
+			?>
+			<div class="updated">
+				<p>
+					<strong>
+						<?php echo sprintf(__( 'You selected to delete the show "%s". Please confirm this action.', 'podlove-podcasting-plugin-for-wordpress' ), $show->title); ?>
+					</strong>
+				</p>
+				<p>
+					<?php echo self::get_action_link( $show, __( 'Delete permanently', 'podlove-podcasting-plugin-for-wordpress', $show->id ), 'delete', 'button' ) ?>
+					<?php echo self::get_action_link( $show, __( 'Don\'t change anything', 'podlove-podcasting-plugin-for-wordpress', $show->id ), 'keep', 'button-primary' ) ?>
+				</p>
+			</div>
+			<?php endif;
+
+			$action = isset( $_REQUEST['action'] ) ? $_REQUEST['action'] : NULL;
+			switch ( $action ) {
+				case 'new':   $this->new_template();  break;
+				case 'edit':  $this->edit_template(); break;
+				case 'index': $this->view_template(); break;
+				default:      $this->view_template(); break;
+			}
+			?>
+		</div>
+		<?php
+	}
+
+	private function new_template() {
+		$show = new Show;
+		?>
+		<h3><?php echo __( 'Add New Show', 'podlove-podcasting-plugin-for-wordpress' ); ?></h3>
+		<?php
+		$this->form_template( $show, 'create', __( 'Add New Show', 'podlove-podcasting-plugin-for-wordpress' ) );
+	}
+		
+	private function view_template() {
+		$this->table->prepare_items();
+		$this->table->display();
+	}
+	
+	private function form_template( $show, $action, $button_text = NULL ) {
+		$form_args = array(
+			'context' => 'podlove_show',
+			'hidden'  => array(
+				'show'      => $show->id,
+				'action'    => $action
+			),
+			'submit_button' => false, // for custom control in form_end
+			'form_end' => function() {
+				echo "<p>";
+				submit_button( __('Save Changes'), 'primary', 'submit', false );
+				echo " ";
+				submit_button( __('Save Changes and Continue Editing', 'podlove-podcasting-plugin-for-wordpress'), 'secondary', 'submit_and_stay', false );
+				echo "</p>";
+			}
+		);
+
+		\Podlove\Form\build_for( $show, $form_args, function ( $form ) {
+			$wrapper = new \Podlove\Form\Input\TableWrapper( $form );
+			$show  = $form->object;
+			$generic_feed = \Podlove\Model\Feed::first();
+
+	 		$wrapper->string('title', [
+	 			'label'       => __('Title', 'podlove-podcasting-plugin-for-wordpress'),
+	 			'html'        => ['class' => 'regular-text podlove-check-input']
+	 		]);
+
+	 		$wrapper->string('slug', [
+	 			'label'       => __('Slug', 'podlove-podcasting-plugin-for-wordpress') . \Podlove\get_help_link('podlove_help_shows_slug'),
+	 			'html'        => ['class' => 'regular-text required podlove-check-input'],
+	 			'description' => 'Feed identifier. <span id="feed_subscribe_url_preview" data-show-feed-base-url="' . get_site_url() . '" data-show-feed-slug="' . ( isset($generic_feed) ? $generic_feed->slug : '' ) . '" data-show-preview-string="' . __('URL preview:', 'podlove-podcasting-plugin-for-wordpress') . '"></span>'
+	 		]);
+
+	 		$wrapper->string('subtitle', [
+	 			'label'       => __('Subtitle', 'podlove-podcasting-plugin-for-wordpress'),
+	 			'html'        => ['class' => 'regular-text podlove-check-input']
+	 		]);
+
+	 		$wrapper->text('summary', [
+	 			'label'       => __('Summary', 'podlove-podcasting-plugin-for-wordpress'),
+	 			'html'        => array( 'rows' => 3, 'cols' => 40, 'class' => 'autogrow podlove-check-input' )
+	 		]);
+
+	 		$wrapper->upload('image', [
+	 			'label' => __('Image', 'podlove-podcasting-plugin-for-wordpress'),
+	 			'html'  => ['class' => 'regular-text podlove-check-input', 'data-podlove-input-type' => 'url'],
+ 				'media_button_text' => __("Use Image for Show", 'podlove-podcasting-plugin-for-wordpress')
+	 		]);
+
+	 		$wrapper->select( 'language', array(
+	 			'label'       => __( 'Language', 'podlove-podcasting-plugin-for-wordpress' ),
+	 			'description' => '',
+	 			'default'     => get_bloginfo( 'language' ),
+	 			'options'  => \Podlove\Locale\locales()
+	 		) );
+
+		} );
+	}
+	
+	private function edit_template() {
+		$show = Show::find_by_id( $_REQUEST['show'] );
+		echo '<h3>' . sprintf( __( 'Edit Show: %s', 'podlove-podcasting-plugin-for-wordpress' ), $show->title ) . '</h3>';
+		$this->form_template( $show, 'save' );
+	}
+
+	private static function get_action_link( $show, $title, $action = 'edit', $class = 'link' ) {
+		return sprintf(
+			'<a href="?page=%s&amp;action=%s&amp;show=%s" class="%s">' . $title . '</a>',
+			self::MENU_SLUG,
+			$action,
+			$show->id,
+			$class
+		);
+	}
+}

--- a/lib/modules/shows/settings/show_list_table.php
+++ b/lib/modules/shows/settings/show_list_table.php
@@ -1,0 +1,110 @@
+<?php
+namespace Podlove\Modules\Shows\Settings;
+
+use \Podlove\Modules\Shows\Model\Show;
+
+class ShowListTable extends \Podlove\List_Table {
+
+	function __construct() {
+		parent::__construct( array(
+		    'singular'  => 'show',   // singular name of the listed records
+		    'plural'    => 'shows',  // plural name of the listed records
+		    'ajax'      => false       // does this table support ajax?
+		) );
+	}
+
+	public function column_title($show) {
+
+		$link = function ( $title, $action = 'edit' ) use ( $show ) {
+			return sprintf(
+				'<a href="?page=%s&action=%s&show=%s">' . $title . '</a>',
+				Settings::MENU_SLUG,
+				$action,
+				$show->id
+			);
+		};
+
+		$actions = [
+			'edit'   => $link( __( 'Edit', 'podlove-podcasting-plugin-for-wordpress' ) ),
+			'delete' => $link( __( 'Delete', 'podlove-podcasting-plugin-for-wordpress' ), 'confirm_delete' )
+		];
+	
+		return sprintf(
+			'%1$s %2$s',
+			$link($show->title),
+			$this->row_actions($actions)
+		);
+	}
+
+	public function column_image($show) {
+		if ($show->image) {
+			return $show->image()->setWidth(64)->setHeight(64)->image();
+		} else {
+			return '';
+		}
+	}
+
+	public function column_episodes($show) {
+		if ( $term = get_term($show->id) )
+			return $term->count;
+	}
+
+	public function column_show_feeds($show) {
+		?> <ul> <?php
+		foreach (\Podlove\Model\Feed::find_all_by_discoverable(1) as $feed) {
+			$show_feed_url = $feed->get_subscribe_url();
+
+			printf('<li><a href="%1$s">%1$s</a></li>', 
+					str_replace(
+							home_url(),
+							home_url() . '/show/' . $show->slug,
+							$show_feed_url
+						)
+				);
+		}
+		?> </ul> <?php
+	}
+
+	public function get_columns(){
+		return array(
+			'image' => __( 'Image', 'podlove-podcasting-plugin-for-wordpress' ),
+			'title' => __( 'Show', 'podlove-podcasting-plugin-for-wordpress' ),
+			'episodes' => __( 'Episodes', 'podlove-podcasting-plugin-for-wordpress' ),
+			'show_feeds' => __( 'Subscribe URLs', 'podlove-podcasting-plugin-for-wordpress' )
+		);
+	}
+
+	public function prepare_items() {
+		// number of items per page
+		$per_page = get_user_meta( get_current_user_id(), 'podlove_shows_per_page', true);
+		if (empty($per_page)) {
+			$per_page = 10;
+		}
+
+		// define column headers
+		$columns = $this->get_columns();
+		$hidden = array();
+		$sortable = $this->get_sortable_columns();
+		$this->_column_headers = array( $columns, $hidden, $sortable );
+		
+		// retrieve data
+		$data = Show::all();
+
+		// get current page
+		$current_page = $this->get_pagenum();
+		// get total items
+		$total_items = count( $data );
+		// extrage page for current page only
+		$data = array_slice( $data, ( ( $current_page - 1 ) * $per_page ) , $per_page );
+		// add items to table
+		$this->items = $data;
+		
+		// register pagination options & calculations
+		$this->set_pagination_args( array(
+		    'total_items' => $total_items,
+		    'per_page'    => $per_page,
+		    'total_pages' => ceil( $total_items / $per_page )
+		) );
+	}
+
+}

--- a/lib/modules/shows/shows.php
+++ b/lib/modules/shows/shows.php
@@ -1,0 +1,164 @@
+<?php
+namespace Podlove\Modules\Shows;
+use \Podlove\Model;
+use \Podlove\Modules\Shows\Model\Show;
+
+class Shows extends \Podlove\Modules\Base {
+
+	protected $module_name = 'Shows';
+	protected $module_description = 'Release specific episodes of a podcast as Shows.';
+	protected $module_group = 'metadata';
+
+	public function load() {
+		add_action( 'init', array($this, 'register_show_taxonomy') );
+		add_action( 'podlove_register_settings_pages', function($handle) {
+			new \Podlove\Modules\Shows\Settings\Settings($handle);
+		} );
+		add_action( 'admin_print_styles', array($this, 'scripts_and_styles') );
+
+		add_filter( 'podlove_feed_title', array($this, 'override_feed_title'), 20 );
+		add_filter( 'podlove_feed_itunes_subtitle', array($this, 'override_feed_subtitle'), 5 );
+		add_filter( 'podlove_feed_itunes_summary', array($this, 'override_feed_summary'), 5 );
+		add_filter( 'podlove_rss_feed_description', array($this, 'override_feed_description'), 20 );
+		add_filter( 'podlove_feed_itunes_image', array($this, 'override_feed_image'), 5 );
+		add_filter( 'podlove_feed_language', array($this, 'override_feed_language'), 5 );
+
+		add_filter( 'set-screen-option', function($status, $option, $value) {
+			if ($option == 'podlove_shows_per_page')
+				return $value;
+			
+			return $status;
+		}, 10, 3 );
+
+		// Template accessors (Provides episode.show and podcasts.shows)
+		\Podlove\Template\Episode::add_accessor(
+			'show', array('\Podlove\Modules\Shows\TemplateExtensions', 'accessorEpisodesShow'), 5
+		);
+
+		\Podlove\Template\Podcast::add_accessor(
+			'shows', array('\Podlove\Modules\Shows\TemplateExtensions', 'accessorPodcastShows'), 4
+		);
+	}
+
+	public function register_show_taxonomy() {
+		register_taxonomy(
+			'shows',
+			'podcast',
+			array(
+				'label' => __( 'Show' ),
+				'rewrite' => array( 'slug' => 'show' ),
+				'show_ui' => true,
+				'show_in_menu' => false,
+				'show_in_quick_edit' => false,
+				'hierarchical' => true,
+				'show_admin_column' => true,
+				'meta_box_cb' => array($this, 'episode_show_meta_box')
+			)
+		);
+	}
+
+	public function override_feed_title($title) {
+		return self::get_feed_modification($title, 'title');
+	}
+
+	public function override_feed_subtitle($subtitle) {
+		return self::get_feed_modification($subtitle, 'subtitle');
+	}
+
+	public function override_feed_description($description) {
+		return self::get_feed_modification($description, 'description'); 
+	}
+
+	public function override_feed_summary($summary) {
+		return self::get_feed_modification($summary, 'summary'); 
+	}
+
+	public function override_feed_image($image) {
+		return self::get_feed_modification($image, 'image'); 
+	}
+
+	public function override_feed_language($language) {
+		return self::get_feed_modification($language, 'language'); 
+	}
+
+	/*
+	 * Handles the feed modifications
+	 *
+	 * @param string $previous_value Previous value
+	 * @param string $new_value Used to replace $previous_value
+	 */
+	private static function get_feed_modification($previous_value, $new_value) {
+		global $wp_query;
+
+		if ( isset($wp_query->query_vars['shows']) ) {
+			$show = Show::find_one_term_by_property('slug', $wp_query->query_vars['shows']);
+
+			switch ($new_value) {
+				case 'title':
+					return $show->title;
+				break;
+				case 'subtitle':
+					return sprintf('<itunes:subtitle>%s</itunes:subtitle>', $show->subtitle);
+				break;
+				case 'description':
+					return $show->subtitle;
+				break;
+				case 'summary':
+					return sprintf('<itunes:summary>%s</itunes:summary>', $show->summary);
+				break;
+				case 'language':
+					return $show->language;
+				break;
+				case 'image':
+					return sprintf('<itunes:image>%s</itunes:image>', $show->image);
+				break;
+			}
+		}
+
+		return $previous_value;
+	}
+
+	/**
+	 * Provides the Show meta box for the Episode UI
+	 *
+	 * NOTE: We do NOT use the default WordPress UI since it cannot be modified sufficiently enough
+	 */
+	public function episode_show_meta_box() {
+		$post = get_post();
+		$taxonomy = get_taxonomy('shows');
+		?>
+		<div id="taxonomy-shows" class="categorydiv">
+			<input type='hidden' name='tax_input[shows][]' value='0' />
+			<ul id="showschecklist" class="categorychecklist form-no-clear">
+				<?php
+					$terms = get_terms( 'shows', array('hide_empty' => false) );
+					$postterms = get_the_terms( $post->id, 'shows' );
+					$current = ( isset($postterms[0]) ? $postterms[0]->term_id : 0 ); // Fetch the first element of the term array. We expect that there is only one "Show" term since a show is a unique property of an episode.
+
+					foreach ($terms as $term) {
+						$id = 'shows-' . $term->term_id;
+
+						echo "<li id='$id' class='fubar'><label class='selectit'>" .
+						"<input type='radio' id='in-$id' name='tax_input[shows]'" . 
+						checked( $current, $term->term_id, false ) . 
+						"value='$term->term_id' />$term->name" .
+						"</label></li>";
+					}
+				?>
+			</ul>
+		</div>
+		<?php
+	}
+
+	public function scripts_and_styles() {
+		if (filter_input(INPUT_GET, 'page') !== 'podlove_shows_settings')
+			return;
+
+		wp_enqueue_script(
+			'podlove_shows_admin_script',
+			$this->get_module_url() . '/js/admin.js',
+			['jquery'],
+			\Podlove\get_plugin_header('Version')
+		);
+	}
+}

--- a/lib/modules/shows/template_extensions.php
+++ b/lib/modules/shows/template_extensions.php
@@ -3,26 +3,6 @@ namespace Podlove\Modules\Shows;
 use \Podlove\Modules\Shows\Model\Show;
 
 class TemplateExtensions {
-
-	/**
-	 * Episode Show
-	 *
-	 * **Examples**
-	 * 
-	 * ```
-	 * This episode is part of the Show: {{ episode.show.title }} which deals with 
-	 * {{ episode.show.summary }}
-	 * ```
-	 *
-	 * @accessor
-	 * @dynamicAccessor episode.show
-	 */
-	public static function accessorPodcastShows($return, $method_name, $episode) {
-		return $episode->with_blog_scope(function() use ($return, $method_name, $episode) {
-			return Show::all();
-		});
-	}
-
 	/**
 	 * List of all Podcast shows
 	 *
@@ -39,6 +19,25 @@ class TemplateExtensions {
 	 *
 	 * @accessor
 	 * @dynamicAccessor podcast.shows
+	 */
+	public static function accessorPodcastShows($return, $method_name, $episode) {
+		return $episode->with_blog_scope(function() use ($return, $method_name, $episode) {
+			return Show::all();
+		});
+	}
+
+	/**
+	 * Episode Show
+	 *
+	 * **Examples**
+	 * 
+	 * ```
+	 * This episode is part of the Show: {{ episode.show.title }} which deals with 
+	 * {{ episode.show.summary }}
+	 * ```
+	 *
+	 * @accessor
+	 * @dynamicAccessor episode.show
 	 */
 	public static function accessorEpisodesShow($return, $method_name, $episode) {
 		return $episode->with_blog_scope(function() use ($return, $method_name, $episode) {

--- a/lib/modules/shows/template_extensions.php
+++ b/lib/modules/shows/template_extensions.php
@@ -1,0 +1,48 @@
+<?php 
+namespace Podlove\Modules\Shows;
+use \Podlove\Modules\Shows\Model\Show;
+
+class TemplateExtensions {
+
+	/**
+	 * Episode Show
+	 *
+	 * **Examples**
+	 * 
+	 * ```
+	 * This episode is part of the Show: {{ episode.show.title }} which deals with 
+	 * {{ episode.show.summary }}
+	 * ```
+	 *
+	 * @accessor
+	 * @dynamicAccessor episode.show
+	 */
+	public static function accessorPodcastShows($return, $method_name, $episode) {
+		return $episode->with_blog_scope(function() use ($return, $method_name, $episode) {
+			return Show::all();
+		});
+	}
+
+	/**
+	 * List of all Podcast shows
+	 *
+	 * **Examples**
+	 * 
+	 * ```
+	 * This podcast features several shows:
+	 * <ul>
+	 * 	{% for show in podcast.shows %}
+	 *  	<li>{{ show.title }}</li>
+	 *  {% endfor %}
+	 * </ul>
+	 * ```
+	 *
+	 * @accessor
+	 * @dynamicAccessor podcast.shows
+	 */
+	public static function accessorEpisodesShow($return, $method_name, $episode) {
+		return $episode->with_blog_scope(function() use ($return, $method_name, $episode) {
+			return Show::find_one_by_episode_id($episode->id);
+		});
+	}
+}

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: eteubert, chemiker
 Donate link: http://podlove.org/donations/
 Tags: podlove, podcast, publishing, rss, feed, audio, mp3, m4a, player, webplayer, iTunes, radio
-Requires at least: 3.5
+Requires at least: 4.4
 Tested up to: 4.7.3
 Stable tag: trunk
 License: MIT


### PR DESCRIPTION
The Shows Module adds show support to a Podcast (Cpt. Obvious strikes back). The initial version of the module features

* Admin UI to create, modify and delete shows
* Template extensions (podcast.shows, episode.show)
* Handling to overwrite specific feed attributes (Image, Subtitle, Title, Summary and language) to create show-specific feeds

It must be noted that this commit does include a minor modification of lib/feeds/rss.php:56/98 to make the feed filter functions work.

@eteubert Some of the documentation/help may be adjusted. However, imho the module is advanced enough to start the review process :)