### PR TITLE
Added null check to prevent fatal error

### DIFF
--- a/includes/episode_number_column.php
+++ b/includes/episode_number_column.php
@@ -19,6 +19,9 @@ function podlove_add_episodeno_column_to_episodes_table($columns)
 function podlove_add_episodeno_column_content_to_episodes_table($column_name)
 {
 	if ($column_name === 'episode_number') {
-		echo \Podlove\get_episode()->number();
+	    //check for null to prevent fatal error
+        if(\Podlove\get_episode() != null) {
+            echo \Podlove\get_episode()->number();
+        }
 	}
 }


### PR DESCRIPTION
At Medien-KuH we don't use the new iOS 11 meta data such as episode number, therefore we didn't migrate the episode titles. When duplicating an episode the whole episode list went blank with this error message in the log:

> PHP Fatal error:  Call to a member function number() on null in /[path-to-wordpress]/wp-content/plugins/podlove-podcasting-plugin-for-wordpress/includes/episode_number_column.php on line 22

I added a simple null check to prevent this error.

The episode fixes itself after opening, therefore only this easy check to prevent the fatal error.
