### PR TITLE
Fixed depreation warning when using multiple categories

### DIFF
--- a/includes/permalinks.php
+++ b/includes/permalinks.php
@@ -172,8 +172,12 @@ function podlove_generate_custom_post_link( $post_link, $id, $leavename = false,
 		$cats = get_the_category( $post->ID );
 
 		if ( $cats ) {
-			usort( $cats, '_usort_terms_by_ID' ); // order by ID
-			
+            if( function_exists( 'wp_list_sort' ) ) {
+                $cats = wp_list_sort( $cats, 'term_id', 'ASC' );
+            } else {
+                usort( $cats, '_usort_terms_by_ID' );
+            }
+
 			$category_object = apply_filters( 'post_link_category', $cats[0], $cats, $post );
 			$category_object = get_term( $category_object, 'category' );
 			$category = $category_object->slug;


### PR DESCRIPTION
_usort_terms_by_ID is deprecated and produces a notice. 
`Notice: _usort_terms_by_ID ist seit Version 4.7.0 veraltet! Benutze stattdessen wp_list_sort(). in /mnt/web203/d1/18/53783218/htdocs/lieblings-plaetzchen.com/wp-includes/functions.php on line 3853`
When selecting multuple categories for an episode, these notices will be visible multiple times in the backend and frontend. This PR fixes that while ensuring backwards compatibility.
