### PR TITLE
Adding ability to specify visible components in v4 player

### DIFF
--- a/lib/helper.php
+++ b/lib/helper.php
@@ -226,8 +226,23 @@ function get_webplayer_defaults() {
 		'version'         => 'player_v4',
 		'playerv3theme'   => 'pwp-dark-green.min.css',
 		'podigeetheme'    => 'default',
-		'playerv4_color_primary'   => '#2B8AC6',
-		'playerv4_color_secondary' => ''
+		'playerv4_color_primary'   => get_background_color(),
+		'playerv4_color_secondary' => get_header_textcolor(),
+		'playerv4_visible_components' => [
+			'controlChapters' => "on",
+			'controlSteppers' => "on",
+			'episodeTitle' => "on",
+			'poster' => "on",
+			'progressbar' => "on",
+			'showTitle' => "on",
+			'subtitle' => "on",
+			'tabAudio' => "on",
+			'tabChapters' => "on",
+			'tabFiles' => "on",
+			'tabShare' => "on",
+			'tabInfo' => "on",
+			'tabTranscripts' => "on"
+		]
 	];
 }
 

--- a/lib/modules/podlove_web_player/player_v4/html5printer.php
+++ b/lib/modules/podlove_web_player/player_v4/html5printer.php
@@ -97,6 +97,7 @@ class Html5Printer implements \Podlove\Modules\PodloveWebPlayer\PlayerPrinterInt
             'theme'     => [
                 'main' => self::sanitize_color($player_settings['playerv4_color_primary'], '#000'),
             ],
+			'visibleComponents' => array_keys($player_settings['playerv4_visible_components'], "on")
         ];
 
         if (!Module::use_cdn()) {

--- a/lib/modules/podlove_web_player/player_v4/module.php
+++ b/lib/modules/podlove_web_player/player_v4/module.php
@@ -214,6 +214,32 @@ class Module
             'position' => 495,
         ];
 
+		$form_data[] = [
+			'type' => 'multiselect',
+			'key'  => 'playerv4_visible_components',
+			'options' => [
+				'label' => 'Select Visible Components',
+				'description' => __('Select which player components you would like to display', 'podlove-podcasting-plugin-for-wordpress'),
+                'multi_values' => \Podlove\get_webplayer_settings()['playerv4_visible_components'],
+				'options' => [
+					'controlChapters' => 'Chapters Control',
+					'controlSteppers' => 'Playback Steppers',
+					'episodeTitle' => 'Episode Title',
+					'poster' => 'Episode Image',
+					'progressbar' => 'Progress Bar',
+					'showTitle' => 'Podcast Title',
+					'subtitle' => 'Episode Subtitle',
+					'tabAudio' => 'Audio Controls Tab',
+					'tabChapters' => 'Chapters Tab',
+					'tabFiles' => 'Download Tab',
+					'tabInfo' => 'Info Tab',
+					'tabShare' => 'Sharing Tab',
+					'tabTranscripts' => "Transcripts Tab"
+				],
+			],
+			'position' => 490
+		];
+
         // remove "chapter visibility" setting
         $form_data = array_filter($form_data, function ($entry) {
             return $entry['key'] !== 'chaptersVisible';


### PR DESCRIPTION
In order to customize the appearance of the v4 player in the publishing plugin I added a form field to select which components are visible in the player embed. I also updated the default values for the primary and secondary color to pull from the configured theme settings.