### PR TITLE
Fixed download list description in analytics on mobile

### DIFF
--- a/css/admin.css
+++ b/css/admin.css
@@ -676,6 +676,10 @@ label.podlove_cc_license_selector_label {
 	line-height: 1.5em;
 }
 
+#the-list .downloads-description {
+	display: table-cell;
+}
+
 .wp-list-table .column-episode_number {
 	width: 30px;
 }

--- a/lib/downloads_list_table.php
+++ b/lib/downloads_list_table.php
@@ -133,7 +133,7 @@ class Downloads_List_Table extends \Podlove\List_Table {
 		$columns = count($this->get_columns()) - $hidden_columns;
 
 		echo '<tr>';
-		echo "<td colspan=\"{$columns}\">";
+		echo "<td class=\"downloads-description\" colspan=\"{$columns}\">";
 		echo $this->column_episode($item);
 		echo "</td>";
 		echo '</tr>';


### PR DESCRIPTION
There were a problem with the download list descriptions on mobile view:

![grafik](https://user-images.githubusercontent.com/825911/61593591-c73a7880-abe1-11e9-8462-f6be8a39cf7c.png)

I was able to fix it with some css:

![grafik](https://user-images.githubusercontent.com/825911/61593601-de796600-abe1-11e9-87f1-533d86dcb67c.png)
