### PR TITLE
Add Google Analytics support

### DIFF
--- a/includes/downloads.php
+++ b/includes/downloads.php
@@ -10,7 +10,7 @@ function podlove_get_query_var($var_name) {
 		return $_GET[$var_name];
 	} else {
 		return get_query_var($var_name);
-	}	
+	}
 }
 
 function podlove_get_remote_addr() {
@@ -23,16 +23,19 @@ function podlove_get_remote_addr() {
 	return $_SERVER['REMOTE_ADDR'];
 }
 
-function ga_track_download($request_id, $media_file, $ua_string, $ptm_context, $ptm_source) {	
+function ga_track_download($request_id, $media_file, $ua_string, $ptm_context, $ptm_source) {
 	// GA Tracking
 	$debug_ga = false;
 	$ga_collect_endpoint = 'https://www.google-analytics.com/' . ($debug_ga ? 'debug/' : '') . 'collect';
-	
+
 	$ga_tracking_id = trim(\Podlove\get_setting('tracking', 'ga'));
 	if (!$ga_tracking_id || $ga_tracking_id === '') {
 		return;
 	}
-	
+
+	$episode = $media_file->episode();
+	$title = $episode->title();
+
 	$ga_params = array(
 		// Basics
 		'v' => '1', // version
@@ -41,54 +44,54 @@ function ga_track_download($request_id, $media_file, $ua_string, $ptm_context, $
 		'ua' => $ua_string, // user agent override
 		'uip' => podlove_get_remote_addr(), // IP override
 		'ds' => 'podlove', // data source
-		
+
 		// We highjack the campaign fields for context/source data.
 		// Source / Medium maps to Podlove context / Podlove source.
 		// This way all Podlove sources can be easily grouped into GA Channels.
 		'cs' => $ptm_context, // campaign source
 		'cm' => $ptm_source, // campaign medium
-		'ci' => $media_file->episode()->number, // campaign id
-		'cn' => $media_file->episode()->title(), // campaign name
-		
+		'ci' => $episode->number, // campaign id
+		'cn' => $title, // campaign name
+
 		// Pageview params
 		't' => 'pageview', // hit type
-		'dh' => $_SERVER[HTTP_HOST], // document host
-		'dp' => $_SERVER[REQUEST_URI], // document path
-		'dt' => $media_file->episode()->title(), // document title
+		'dh' => $_SERVER['HTTP_HOST'], // document host
+		'dp' => $_SERVER['REQUEST_URI'], // document path
+		'dt' => $title, // document title
 	);
-	
+
 	$ga_param_fragments = array();
 	array_walk($ga_params, function($item, $key) use(&$ga_param_fragments) {
 		array_push($ga_param_fragments, sprintf('%s=%s', $key, rawurlencode($item)));
 	});
-	
+
 	$body = implode('&', $ga_param_fragments);
 	$curl = new \Podlove\Http\Curl();
 	$curl->request( $ga_collect_endpoint, array(
 		'method'  => 'POST',
 		'body'    => $body,
 	));
-	
+
 	if (!$curl->isSuccessful()) {
 		if ($debug_ga) {
 			header('x-ga-debug: http error');
 		}
-		\Podlove\Log::get()->addError('GA Measurement Protocol request failed.');
+		\Podlove\Log::get()->addDebug('GA Measurement Protocol request failed.');
 	} else {
-		\Podlove\Log::get()->addInfo('GA Measurement Protocol request successful: ' . $body);
+		\Podlove\Log::get()->addDebug('GA Measurement Protocol request successful: ' . $body);
 		if (!$debug_ga) {
 			return;
 		}
-		
+
 		$response = json_decode($curl->get_response()['body'], true);
 		$hit_paring_result = $response['hitParsingResult'][0];
 		if ($hit_paring_result['valid']) {
 			header('x-ga-debug: valid');
-			\Podlove\Log::get()->addInfo('GA Measurement Protocol hit valid.');
+			\Podlove\Log::get()->addDebug('GA Measurement Protocol hit valid.');
 		} else {
-			$debug_message = sprintf('%s(%s): %s', $hit_paring_result['parserMessage'][0]['messageType'], $response['hitParsingResult'][0]['parserMessage'][0]['parameter'], $response['hitParsingResult'][0]['parserMessage'][0]['description']); 
+			$debug_message = sprintf('%s(%s): %s', $hit_paring_result['parserMessage'][0]['messageType'], $response['hitParsingResult'][0]['parserMessage'][0]['parameter'], $response['hitParsingResult'][0]['parserMessage'][0]['description']);
 			header(sprintf('x-ga-debug: ' . $debug_message ));
-			\Podlove\Log::get()->addError('GA Measurement Protocol hit invalid.', $hit_paring_result['parserMessage'][0]);
+			\Podlove\Log::get()->addDebug('GA Measurement Protocol hit invalid.', $hit_paring_result['parserMessage'][0]);
 		}
 	}
 }
@@ -104,7 +107,7 @@ function podlove_handle_media_file_tracking(\Podlove\Model\MediaFile $media_file
 	$intent = new Model\DownloadIntent;
 	$intent->media_file_id = $media_file->id;
 	$intent->accessed_at = date('Y-m-d H:i:s');
-	
+
 	$ptm_source  = trim(podlove_get_query_var('ptm_source'));
 	$ptm_context = trim(podlove_get_query_var('ptm_context'));
 
@@ -132,13 +135,13 @@ function podlove_handle_media_file_tracking(\Podlove\Model\MediaFile $media_file
 	} else {
 		$intent->request_id = sha1($ip_string . $ua_string);
 	}
-	
+
 	if (Geo_Ip::is_enabled()) {
 		$intent = $intent->add_geo_data($ip_string);
 	}
 
 	$intent->save();
-	
+
 	ga_track_download($intent->request_id, $media_file, $ua_string, $ptm_context, $ptm_source);
 }
 
@@ -172,7 +175,7 @@ function podlove_handle_media_file_download() {
 		exit;
 	}
 
-	// if a file exists but no valid episode reference, 
+	// if a file exists but no valid episode reference,
 	// that means it has been removed
 	$episode = $media_file->episode();
 

--- a/includes/downloads.php
+++ b/includes/downloads.php
@@ -23,7 +23,7 @@ function podlove_get_remote_addr() {
 	return $_SERVER['REMOTE_ADDR'];
 }
 
-function ga_track_download($request_id, $media_file, $ua_string, $ip_string, $ptm_context, $ptm_source) {	
+function ga_track_download($request_id, $media_file, $ua_string, $ptm_context, $ptm_source) {	
 	// GA Tracking
 	$debug_ga = false;
 	$ga_collect_endpoint = 'https://www.google-analytics.com/' . ($debug_ga ? 'debug/' : '') . 'collect';
@@ -39,8 +39,6 @@ function ga_track_download($request_id, $media_file, $ua_string, $ip_string, $pt
 		'tid' => $ga_tracking_id, // tracking id
 		'cid' => $request_id, // client id
 		'ua' => $ua_string, // user agent override
-		// We do not use $ip_string here, because Google Measurement protocol does not seem to like
-		// the IPv6 representation that $ip_string stores.
 		'uip' => podlove_get_remote_addr(), // IP override
 		'ds' => 'podlove', // data source
 		
@@ -141,7 +139,7 @@ function podlove_handle_media_file_tracking(\Podlove\Model\MediaFile $media_file
 
 	$intent->save();
 	
-	ga_track_download($intent->request_id, $media_file, $ua_string, $ip_string, $ptm_context, $ptm_source);
+	ga_track_download($intent->request_id, $media_file, $ua_string, $ptm_context, $ptm_source);
 }
 
 function podlove_handle_media_file_download() {

--- a/lib/settings/expert/tab/tracking.php
+++ b/lib/settings/expert/tab/tracking.php
@@ -94,6 +94,28 @@ class Tracking extends Tab {
 		);
 
 		add_settings_field(
+			/* $id       */ 'podlove_setting_tracking_google_analytics',
+			/* $title    */ sprintf(
+				'<label for="mode">%s</label>',
+				__( 'Google Analytics Tracking ID', 'podlove-podcasting-plugin-for-wordpress' )
+			),
+			/* $callback */ function () {
+				?>
+
+				<div><input type="text" name="podlove_tracking[ga]" value="<?php echo(\Podlove\get_setting( 'tracking', 'ga' )) ?> " /></div>
+				<div> 
+				<?php echo sprintf(
+								'<div>%s</div>',
+								__( 'Google Analytics Tracking ID. If entered, Podlove Publisher will log download intents to GA. Leave blank to deactivate GA reporting.', 'podlove-podcasting-plugin-for-wordpress' )
+							); ?>
+				</div>
+				<?php
+			},
+			/* $page     */ Settings::$pagehook,  
+			/* $section  */ 'podlove_settings_episode'
+		);
+		
+		add_settings_field(
 			/* $id       */ 'podlove_status_location_database',
 			/* $title    */ sprintf(
 				'<label for="mode">%s</label>',


### PR DESCRIPTION
These commits add support for Google Analytics.

A Google Analytics tracking ID can be set from the Podlove Publisher tracking settings.
If provided, Podlove Publisher will forward available tracking data to Google Analytics.