### PR TITLE
Check if podlovePlayer is defined

### DIFF
--- a/lib/modules/podlove_web_player/player_v4/pwp4.js
+++ b/lib/modules/podlove_web_player/player_v4/pwp4.js
@@ -3,7 +3,9 @@ jQuery(function () {
     var that = jQuery(this);
     var id = that.attr("id");
     var config = that.data("episode");
-
-    podlovePlayer("#" + id, config);
+    
+    if (typeof podlovePlayer === "function") {
+      podlovePlayer("#" + id, config);
+    }
   })
 });


### PR DESCRIPTION
If the function is undefined (for example in IE11), it may cause problems with other scripts.  
For example, on our site the [a3 Lazy Load plugin](https://wordpress.org/plugins/a3-lazy-load/) ceased working if podlove was embedded on a page.  
Sadly around 25% of our users use Internet Explorer 11, so this affected a large part of our user base.