### PR TITLE
Exposed voice attribute to transcript templates

### DIFF
--- a/lib/modules/transcripts/template/group.php
+++ b/lib/modules/transcripts/template/group.php
@@ -13,12 +13,14 @@ class Group extends Wrapper
 {
 
     private $lines;
+    private $voice;
     private $contributor_id;
 
-    public function __construct($lines, $contributor_id)
+    public function __construct($lines, $contributor_id, $voice)
     {
         $this->lines          = $lines;
         $this->contributor_id = $contributor_id;
+        $this->voice          = $voice;
     }
 
     protected function getExtraFilterArgs()
@@ -76,5 +78,14 @@ class Group extends Wrapper
         }
 
         return new Contributors\Template\Contributor($contributor);
+    }
+
+    public function voice()
+    {
+        if (!$this->voice) {
+            return "Can't find the voice";
+        }
+
+        return $this->voice;
     }
 }

--- a/lib/modules/transcripts/template_extensions.php
+++ b/lib/modules/transcripts/template_extensions.php
@@ -50,7 +50,7 @@ class TemplateExtensions
                 $lines = array_map(function ($line) {
                     return new Template\Line($line);
                 }, $group['items']);
-                return new Template\Group($lines, $group['speaker']);
+                return new Template\Group($lines, $group['speaker'], $group['voice']);
             }, $transcript);
         });
     }


### PR DESCRIPTION
For the case where a contributor object does not exist but the user wants to use the name of the speaker in the context of the transcript template.