### PR TITLE
Adds a quickedit menu to the episode table

### DIFF
--- a/includes/episode_number_column.php
+++ b/includes/episode_number_column.php
@@ -2,10 +2,6 @@
 
 add_filter('manage_edit-podcast_columns', 'podlove_add_episodeno_column_to_episodes_table' );
 add_action('manage_podcast_posts_custom_column', 'podlove_add_episodeno_column_content_to_episodes_table' );
-add_action('quick_edit_custom_box',  'podlove_episodeno_quickedit_form');
-add_action('save_post', 'podlove_episodeno_quickedit_save');
-add_action('admin_footer', 'podlove_episodeno_quickedit_populate_form');
-add_filter('post_row_actions', 'podlove_episodeno_quickedit_extend_action_items', 10, 2);
 
 function podlove_add_episodeno_column_to_episodes_table($columns)
 {
@@ -28,62 +24,4 @@ function podlove_add_episodeno_column_content_to_episodes_table($column_name)
             echo \Podlove\get_episode()->number();
         }
 	}
-}
-
-function podlove_episodeno_quickedit_form($column_name)
-{
-    if ($column_name === 'episode_number') {
-			?>
-			<fieldset class="inline-edit-col-left">
-		    <div class="inline-edit-col">
-					<label class="alignleft">
-						<span class="title"><?php _e('Episode number', 'podlove-podcasting-plugin-for-wordpress') ?></span>
-						<input type="number" name="_podlove_meta[number]" class="podlove_meta_quickedit_episode_number" />
-					</label>
-					<?php wp_nonce_field( '_podlove_meta_quickedit_episode_number', '_podlove_meta_quickedit_episode_number_nonce_field' ); ?>
-		    </div>
-	    </fieldset>
-	    <?php
-		}
-}
-
-function podlove_episodeno_quickedit_save($post_id)
-{
-	if ( wp_verify_nonce($_POST['_podlove_meta_quickedit_episode_number_nonce_field'], '_podlove_meta_quickedit_episode_number') ) {
-		$episode = \Podlove\Model\Episode::find_one_by_post_id($post_id);
-		$episode->number = sanitize_text_field($_POST['_podlove_meta']['number']);
-
-		if ( is_string($episode->number) )
-			$episode->save();
-	}
-}
-
-function podlove_episodeno_quickedit_populate_form()
-{
-	global $current_screen;
-
-  if ($current_screen->post_type !== 'podcast') {
-  	return;
-  }
-
-	?>
-	<script type="text/javascript">
-		function podlove_update_quickedit_episode_number(number) {
-			jQuery('.podlove_meta_quickedit_episode_number').val(number);
-		}
-	</script>
-	<?php
-}
-
-function podlove_episodeno_quickedit_extend_action_items($actions, $post)
-{
-  if ($post->post_type !== 'podcast') {
-		return $actions;
-  }
-
-	$episode = \Podlove\Model\Episode::find_or_create_by_post_id($post->ID);
-	// Not nice but seems like there is in a more elegant way to do this right now
-	$actions["inline hide-if-no-js"] = str_replace( '<button', '<button onclick="podlove_update_quickedit_episode_number(\'' . $episode->number . '\')"', $actions["inline hide-if-no-js"] );
-
-	return $actions;
 }

--- a/includes/episode_number_column.php
+++ b/includes/episode_number_column.php
@@ -1,7 +1,11 @@
-<?php 
+<?php
 
 add_filter('manage_edit-podcast_columns', 'podlove_add_episodeno_column_to_episodes_table' );
 add_action('manage_podcast_posts_custom_column', 'podlove_add_episodeno_column_content_to_episodes_table' );
+add_action('quick_edit_custom_box',  'podlove_episodeno_quickedit_form');
+add_action('save_post', 'podlove_episodeno_quickedit_save');
+add_action('admin_footer', 'podlove_episodeno_quickedit_populate_form');
+add_filter('post_row_actions', 'podlove_episodeno_quickedit_extend_action_items', 10, 2);
 
 function podlove_add_episodeno_column_to_episodes_table($columns)
 {
@@ -24,4 +28,62 @@ function podlove_add_episodeno_column_content_to_episodes_table($column_name)
             echo \Podlove\get_episode()->number();
         }
 	}
+}
+
+function podlove_episodeno_quickedit_form($column_name)
+{
+    if ($column_name === 'episode_number') {
+			?>
+			<fieldset class="inline-edit-col-left">
+		    <div class="inline-edit-col">
+					<label class="alignleft">
+						<span class="title"><?php _e('Episode number', 'podlove-podcasting-plugin-for-wordpress') ?></span>
+						<input type="number" name="_podlove_meta[number]" class="podlove_meta_quickedit_episode_number" />
+					</label>
+					<?php wp_nonce_field( '_podlove_meta_quickedit_episode_number', '_podlove_meta_quickedit_episode_number_nonce_field' ); ?>
+		    </div>
+	    </fieldset>
+	    <?php
+		}
+}
+
+function podlove_episodeno_quickedit_save($post_id)
+{
+	if ( wp_verify_nonce($_POST['_podlove_meta_quickedit_episode_number_nonce_field'], '_podlove_meta_quickedit_episode_number') ) {
+		$episode = \Podlove\Model\Episode::find_one_by_post_id($post_id);
+		$episode->number = sanitize_text_field($_POST['_podlove_meta']['number']);
+
+		if ( is_string($episode->number) )
+			$episode->save();
+	}
+}
+
+function podlove_episodeno_quickedit_populate_form()
+{
+	global $current_screen;
+
+  if ($current_screen->post_type !== 'podcast') {
+  	return;
+  }
+
+	?>
+	<script type="text/javascript">
+		function podlove_update_quickedit_episode_number(number) {
+			jQuery('.podlove_meta_quickedit_episode_number').val(number);
+		}
+	</script>
+	<?php
+}
+
+function podlove_episodeno_quickedit_extend_action_items($actions, $post)
+{
+  if ($post->post_type !== 'podcast') {
+		return $actions;
+  }
+
+	$episode = \Podlove\Model\Episode::find_or_create_by_post_id($post->ID);
+	// Not nice but seems like there is in a more elegant way to do this right now
+	$actions["inline hide-if-no-js"] = str_replace( '<button', '<button onclick="podlove_update_quickedit_episode_number(\'' . $episode->number . '\')"', $actions["inline hide-if-no-js"] );
+
+	return $actions;
 }

--- a/includes/episode_number_quick_edit_form.php
+++ b/includes/episode_number_quick_edit_form.php
@@ -77,7 +77,7 @@ function podlove_episodeno_quickedit_extend_action_items($actions, $post)
 	}
 
 	$episode = \Podlove\Model\Episode::find_or_create_by_post_id($post->ID);
-	// Not nice but seems like there is in a more elegant way to do this right now
+	// Not nice but seems like there is no more elegant way to do this right now
 	$actions["inline hide-if-no-js"] = str_replace( '<button', '<button data-podlove-update-quickedit-episode-number="' . $episode->number . '" ', $actions["inline hide-if-no-js"] );
 
 	return $actions;

--- a/includes/episode_number_quick_edit_form.php
+++ b/includes/episode_number_quick_edit_form.php
@@ -1,0 +1,84 @@
+<?php
+
+add_action('quick_edit_custom_box',  'podlove_episodeno_quickedit_form');
+add_action('save_post', 'podlove_episodeno_quickedit_save');
+add_action('admin_footer', 'podlove_episodeno_quickedit_populate_form');
+add_filter('post_row_actions', 'podlove_episodeno_quickedit_extend_action_items', 10, 2);
+
+function podlove_episodeno_quickedit_form($column_name)
+{
+	if ($column_name === 'episode_number') {
+			?>
+			<fieldset class="inline-edit-col-left">
+				<div class="inline-edit-col">
+					<label class="alignleft">
+						<span class="title"><?php _e('Episode number', 'podlove-podcasting-plugin-for-wordpress') ?></span>
+						<input type="number" name="_podlove_meta[number]" class="podlove_meta_quickedit_episode_number" />
+					</label>
+					<?php wp_nonce_field( '_podlove_meta_quickedit_episode_number', '_podlove_meta_quickedit_episode_number_nonce_field' ); ?>
+			</div>
+		</fieldset>
+		<?php
+		}
+}
+
+function podlove_episodeno_quickedit_save($post_id)
+{
+	if ( ! filter_input(INPUT_POST, "_podlove_meta_quickedit_episode_number_nonce_field") ) {
+		return;
+	}
+
+	if ( wp_verify_nonce($_POST['_podlove_meta_quickedit_episode_number_nonce_field'], '_podlove_meta_quickedit_episode_number') ) {
+		$episode = \Podlove\Model\Episode::find_one_by_post_id($post_id);
+		$episode->number = sanitize_text_field($_POST['_podlove_meta']['number']);
+
+		if ( is_object($episode) && is_string($episode->number) )
+			$episode->save();
+	}
+}
+
+function podlove_episodeno_quickedit_populate_form()
+{
+	global $current_screen;
+
+	if ($current_screen->post_type !== 'podcast') {
+		return;
+	}
+
+	?>
+	<script type="text/javascript">
+		function podlove_update_episode_number_quick_edit_form() {
+			jQuery('button.editinline').on('click', function() {
+				episode_number = jQuery(this).data("podlove-update-quickedit-episode-number");
+
+				if (typeof episode_number === "number") {
+					jQuery('.podlove_meta_quickedit_episode_number').val(episode_number);
+				} else {
+					jQuery('.podlove_meta_quickedit_episode_number').val('');
+				}
+			});
+		}
+
+		jQuery(document).ready(function() {
+			jQuery('body').on('DOMNodeInserted', function() {
+				podlove_update_episode_number_quick_edit_form();
+			});
+
+			podlove_update_episode_number_quick_edit_form();
+		});
+	</script>
+	<?php
+}
+
+function podlove_episodeno_quickedit_extend_action_items($actions, $post)
+{
+	if ($post->post_type !== 'podcast') {
+		return $actions;
+	}
+
+	$episode = \Podlove\Model\Episode::find_or_create_by_post_id($post->ID);
+	// Not nice but seems like there is in a more elegant way to do this right now
+	$actions["inline hide-if-no-js"] = str_replace( '<button', '<button data-podlove-update-quickedit-episode-number="' . $episode->number . '" ', $actions["inline hide-if-no-js"] );
+
+	return $actions;
+}

--- a/plugin.php
+++ b/plugin.php
@@ -21,7 +21,7 @@ function activate_for_current_blog() {
 
 /**
  * Hook: Create a new blog in a multisite environment.
- * 
+ *
  * When a new blog is created, we have to trigger the activation function
  * for in the scope of that blog.
  */
@@ -51,7 +51,7 @@ function delete_blog($blog_id, $drop) {
 
 /**
  * Hook: Activate the plugin.
- * 
+ *
  * In a single blog install, just call activate_for_current_blog().
  * However, in a multisite install, iterate over all blogs and call the activate
  * function for each of them.
@@ -81,14 +81,14 @@ function deactivate() {
 
 /**
  * Hook: Uninstall the plugin.
- * 
+ *
  * In a single blog install, just call uninstall_for_current_blog().
- * However, in a multisite install, iterate over all blogs and call the 
+ * However, in a multisite install, iterate over all blogs and call the
  * uninstall function for each of them.
  */
 function uninstall() {
 	global $wpdb;
-	
+
 	if ( is_multisite() ) {
 		if ( isset( $_GET['networkwide'] ) && ( $_GET['networkwide'] == 1 ) ) {
 			$current_blog = $wpdb->blogid;
@@ -209,6 +209,7 @@ require_once \Podlove\PLUGIN_DIR . 'includes/deprecations.php';
 require_once \Podlove\PLUGIN_DIR . 'includes/detect_duplicate_slugs.php';
 require_once \Podlove\PLUGIN_DIR . 'includes/downloads.php';
 require_once \Podlove\PLUGIN_DIR . 'includes/episode_number_column.php';
+require_once \Podlove\PLUGIN_DIR . 'includes/episode_number_quick_edit_form.php';
 require_once \Podlove\PLUGIN_DIR . 'includes/explicit_content.php';
 require_once \Podlove\PLUGIN_DIR . 'includes/extras.php';
 require_once \Podlove\PLUGIN_DIR . 'includes/feed_discovery.php';
@@ -241,7 +242,7 @@ require_once \Podlove\PLUGIN_DIR . 'includes/wp_rocket.php';
 require_once \Podlove\PLUGIN_DIR . 'lib/tools.php';
 
 // @todo: change to internal module
-new \Podlove\AJAX\Ajax(); 
+new \Podlove\AJAX\Ajax();
 new \Podlove\Settings\Tools\UserAgentRefresh;
 
 \Podlove\Jobs\CronJobRunner::init();


### PR DESCRIPTION
Addresses https://community.podlove.org/t/feature-request-quick-edit-fields-in-episode-table/1911

Disclaimer: This solution works but is kinda hacky (use of str_replace()) and might easily break for future WordPress updates.