### PR TITLE
Bugfix/transcript json url

### DIFF
--- a/lib/modules/transcripts/transcripts.php
+++ b/lib/modules/transcripts/transcripts.php
@@ -391,6 +391,7 @@ class Transcripts extends \Podlove\Modules\Base
     {
         if (Transcript::exists_for_episode($episode->id)) {
             $url = add_query_arg('podlove_transcript', 'json', get_permalink($episode->post_id));
+            $url = str_replace(home_url(), site_url(), $url);
             $config['transcripts'] = $url;
         }
 


### PR DESCRIPTION
Hey there,

In our application we use only the wordpress rest api and have a different url for our frontend. This can be done in wordpress by setting different values for SITE_URL and HOME_URL. The request to the transcript is done to the wrong url in this case, so i replaced the urls here.

Thank you.