### PR TITLE
Added all relevant post status to validate podcast files

### DIFF
--- a/lib/model/podcast.php
+++ b/lib/model/podcast.php
@@ -306,7 +306,13 @@ class Podcast implements Licensable
                 }
             }
 
-            if (isset($args['post_status']) && in_array($args['post_status'], get_post_stati())) {
+            if (isset($args['post_status']) && is_array($args['post_status'])) {
+                $ins = [];
+                foreach ($args['post_status'] as $status) {
+                    $ins[] = '"'.$status.'"';
+                }
+                $where .= ' AND p.post_status IN ('.implode(',', $ins).')';
+            } elseif (isset($args['post_status']) && in_array($args['post_status'], get_post_stati())) {
                 $where .= " AND p.post_status = '".$args['post_status']."'";
             } else {
                 $where .= " AND p.post_status = 'publish'";
@@ -361,7 +367,8 @@ class Podcast implements Licensable
 
             $sql = '
 				SELECT
-					e.*
+                	e.*,
+                    p.post_status
 				FROM
 					'.Episode::table_name().' e
 					INNER JOIN '.$wpdb->posts.' p ON e.post_id = p.ID

--- a/lib/settings/dashboard/file_validation.php
+++ b/lib/settings/dashboard/file_validation.php
@@ -41,7 +41,7 @@ class FileValidation
         }
 
         $podcast = Model\Podcast::get();
-        $episodes = $podcast->episodes();
+        $episodes = $podcast->episodes(['post_status' => ['private', 'draft', 'publish', 'pending', 'future']]);
         $assets = Model\EpisodeAsset::all();
 
         $header = [__('Episode', 'podlove-podcasting-plugin-for-wordpress')];

--- a/views/settings/dashboard/file_validation.php
+++ b/views/settings/dashboard/file_validation.php
@@ -19,7 +19,17 @@ define('ASSET_STATUS_ERROR', '<i class="clickable podlove-icon-remove"></i>');
 			<?php foreach ($episodes as $episode) { ?>
 				<tr>
 					<td>
-						<a href="<?php echo admin_url('post.php?post='.$episode->post_id.'&amp;action=edit'); ?>"><?php echo $episode->slug; ?></a>
+						<a href="<?php echo admin_url('post.php?post='.$episode->post_id.'&amp;action=edit'); ?>">
+							<?php
+                            if (is_null($episode->slug)) {
+                                echo ASSET_STATUS_INACTIVE;
+                                echo ' ';
+                                echo __('Slug is missing', 'podlove-podcasting-plugin-for-wordpress');
+                            } else {
+                                echo $episode->slug;
+                            }
+                            ?>
+						</a>
 					</td>
 					<?php foreach ($assets as $asset) { ?>
 						<?php
@@ -42,7 +52,7 @@ define('ASSET_STATUS_ERROR', '<i class="clickable podlove-icon-remove"></i>');
 						</td>
 					<?php } ?>
 					<td>
-						<?php echo $media_files[$episode->id]['post_status']; ?>
+						<?php echo $episode->post_status; ?>
 					</td>
 				</tr>
 			<?php } ?>


### PR DESCRIPTION
In our podcast one person adds the blog post and the other person does the audio post production. At the end both must get together. To verify this, you can use the validate podcast files on the dashboard. But at the moment drafts and future posts are missing. I think that's a bug, because this line indicates me, that they should be included:

https://github.com/podlove/podlove-publisher/blob/50c06f587bb3a37fe5f91221804734d79c12971b/lib/settings/dashboard/file_validation.php#L26

The problem is, that the template iterates thru $episodes and there the draft and future posts are not included. I fixed this.

![image](https://user-images.githubusercontent.com/825911/95015177-d6bdaa00-064b-11eb-8a84-3fa159cc27a8.png)

If you look at the picture:
* eb034 is a draft, scheduled in the far future, missing media files
* eb033 is a draft, missing media file slug
* eb032 is scheduled, missing media files
* eb031 is valid and published episode

What do you think?
