### PR TITLE
fix: coverart url encoding

### DIFF
--- a/includes/cover_art.php
+++ b/includes/cover_art.php
@@ -26,6 +26,6 @@ add_filter('podlove_episode_form_data', function ($form_data, $episode) {
 
 add_filter('podlove_episode_data_filter', function ($filter) {
     return array_merge($filter, [
-        'cover_art' => FILTER_SANITIZE_URL,
+        'cover_art' => FILTER_SANITIZE_STRING,
     ]);
 });

--- a/lib/feeds/base.php
+++ b/lib/feeds/base.php
@@ -119,7 +119,7 @@ function get_xml_itunesimage_node($url)
     $attr = $doc->createAttribute('href');
 
     // unexpected but true: ampersands are not escaped automatically here
-    $attr->value = htmlentities($url);
+    $attr->value = esc_attr($url);
 
     $node->appendChild($attr);
 

--- a/lib/modules/shownotes/shownotes.php
+++ b/lib/modules/shownotes/shownotes.php
@@ -70,7 +70,7 @@ HTML;
             // $context
             'normal',
             // $priority
-            'high'
+            'low'
         );
     }
 

--- a/lib/modules/shows/shows.php
+++ b/lib/modules/shows/shows.php
@@ -334,7 +334,7 @@ $terms = get_terms('shows', ['hide_empty' => false]);
                     break;
                 case 'image':
                     if ($show->image) {
-                        return sprintf('<itunes:image href="%s"/>', esc_attr($show->image));
+                        return \Podlove\Feeds\get_xml_itunesimage_node($show->image);
                     }
 
                     break;


### PR DESCRIPTION
 fix: various cover art url encoding issues

- do not sanitize episode image url (because it breaks special characters)
- use esc_attr instead of htmlentities for output sanitization
- apply same logic for shows image tag