### PR TITLE
#1194 Avoid indirectly calling wptexturize too early

### DIFF
--- a/bootstrap/constants.php
+++ b/bootstrap/constants.php
@@ -30,7 +30,7 @@ function get_plugin_header($tag_name)
         require_once ABSPATH.'/wp-admin/includes/plugin.php';
     }
 
-    $plugin_data = get_plugin_data(PLUGIN_FILE);
+    $plugin_data = get_plugin_data(PLUGIN_FILE, false, false);
 
     return $plugin_data[$tag_name];
 }


### PR DESCRIPTION
_Resolves Issue #1194_

When collecting parsed plugin metadata from WordPress using `get_plugin_data`, translations and markup are not disabled by default. This causes WordPress to indirectly call `wptexturize`, thus breaking other plugins and translations. 

About the indirect `wptexturize` call from `get_plugin_data()`, see [this comment in the Wordpress Docs](https://developer.wordpress.org/reference/functions/get_plugin_data/#comment-2109). 

The WordPress docs say [this about `wptexturize`](https://developer.wordpress.org/reference/functions/wptexturize/):

> Do not use this function before the ‘init’ action hook; everything will break.

I propose the following change:

Call the `get_plugin_data()` method with additional parameters disabling translations and markup. This avoids calling `wptexturize()`, thus resolving issues caused by that.