### PR TITLE
Major fix bug at install causing by bad episodes table creation.

### DIFF
--- a/lib/model/episode.php
+++ b/lib/model/episode.php
@@ -464,5 +464,5 @@ Episode::property('recording_date', 'DATETIME');
 Episode::property('explicit', 'TINYINT');
 Episode::property('license_name', 'TEXT');
 Episode::property('license_url', 'TEXT');
-Episode::property('soundbite_start', 'VARCHAR(255');
+Episode::property('soundbite_start', 'VARCHAR(255)');
 Episode::property('soundbite_duration', 'VARCHAR(255)');


### PR DESCRIPTION
The new version proposed on WordPress plugin shop is bugged (totally inusable):

Creation of episodes is NOT possible (no saving datas, and no recognization of podcast files),

Caused by a bad creation a tables at installation.

This pull request fix that, correcting a ")" absent in VARCHAR sql declaration.