### PR TITLE
(fixed) Github issue #1233

### DIFF
--- a/lib/modules/contributors/templates/podcast-contributor-table.twig
+++ b/lib/modules/contributors/templates/podcast-contributor-table.twig
@@ -4,9 +4,11 @@
 
 			<div class="podlove-contributors-card">
 				<div class="podlove-contributors-card-inner">
-					<div class="podlove-contributors-card-avatar">
-						{{ contributor.image.html({width: size|default(50), height: size|default(50), class: "", alt: "avatar" }) }}
-					</div>
+				    {% if option.avatars == "yes" %}
+						<div class="podlove-contributors-card-avatar">
+							{{ contributor.image.html({width: size|default(50), height: size|default(50), class: "", alt: "avatar" }) }}
+						</div>
+					{% endif %}
 					<div class="podlove-contributors-card-person">
 						<div style="align-self: center">
 							<div style="font-weight: 400;">{{ contributor.name }}</div>
@@ -28,17 +30,19 @@
 											}}
 								</a>
 							{% endfor %}
-							{% for service in contributor.services({category: "donation"}) %}
-								<a class="podlove-contributors-card-services-service" target="_blank" title="{{ service.title }}" href="{{ service.profileUrl }}">
-									{{
+							{% if option.donations == "yes" %}
+								{% for service in contributor.services({category: "donation"}) %}
+									<a class="podlove-contributors-card-services-service" target="_blank" title="{{ service.title }}" href="{{ service.profileUrl }}">
+										{{
 													service.image.html({
 														width: 20, 
 														class: "",
 														alt: service.title ~ " Icon"
 													}) 
 												}}
-								</a>
-							{% endfor %}
+									</a>
+								{% endfor %}
+							{% endif %}
 						</div>
 					</div>
 				</div>


### PR DESCRIPTION
Ich habe die Optionen avatars, groups und roles beim shortcode podlove-episode-contributor-list eingebaut. 

Aus meiner Sicht macht die Option title in der neuen Darstellung keinen Sinn mehr.

Für den shortcode podlove-podcast-contributor-list fehlt noch die Dokumentation. Die Option avatars könnte eingebaut werden. Bei den Optionen groups und roles bin ich mir nicht sicher. 