### PR TITLE
Feature: MediaFile Upload to WordPress

### DIFF
--- a/client/src/modules/mediafiles/MediaFiles.vue
+++ b/client/src/modules/mediafiles/MediaFiles.vue
@@ -16,8 +16,10 @@
               <MediaSlug />
             </div>
 
-            <!-- TODO: only if upload module is active -->
-            <div class="sm:grid sm:grid-cols-[175px_auto_auto] sm:items-start sm:gap-4 sm:py-6">
+            <div
+              v-if="isMediaUploadEnabled"
+              class="sm:grid sm:grid-cols-[175px_auto_auto] sm:items-start sm:gap-4 sm:py-6"
+            >
               <MediaUpload />
             </div>
 
@@ -58,6 +60,7 @@ export default defineComponent({
     return {
       state: mapState({
         isInitializing: selectors.mediafiles.isInitializing,
+        modules: selectors.settings.modules,
       }),
       dispatch: injectStore().dispatch,
     }
@@ -66,6 +69,9 @@ export default defineComponent({
   computed: {
     isInitializing(): boolean {
       return this.state.isInitializing
+    },
+    isMediaUploadEnabled(): boolean {
+      return this.state.modules.includes('wordpress_file_upload')
     },
   },
 

--- a/client/src/modules/mediafiles/MediaFiles.vue
+++ b/client/src/modules/mediafiles/MediaFiles.vue
@@ -16,6 +16,11 @@
               <MediaSlug />
             </div>
 
+            <!-- TODO: only if upload module is active -->
+            <div class="sm:grid sm:grid-cols-[175px_auto_auto] sm:items-start sm:gap-4 sm:py-6">
+              <MediaUpload />
+            </div>
+
             <div class="sm:grid sm:grid-cols-[175px_auto_auto] sm:items-start sm:gap-4 sm:py-6">
               <AssetsTable />
             </div>
@@ -37,6 +42,7 @@ import Module from '@components/module/Module.vue'
 import { RefreshIcon } from '@heroicons/vue/outline'
 
 import MediaSlug from './components/MediaSlug.vue'
+import MediaUpload from './components/MediaUpload.vue'
 import AssetsTable from './components/AssetsTable.vue'
 
 export default defineComponent({
@@ -44,6 +50,7 @@ export default defineComponent({
     Module,
     RefreshIcon,
     MediaSlug,
+    MediaUpload,
     AssetsTable,
   },
 

--- a/client/src/modules/mediafiles/MediaFiles.vue
+++ b/client/src/modules/mediafiles/MediaFiles.vue
@@ -12,7 +12,10 @@
           <div
             class="mt-10 sm:mt-0 space-y-8 border-b border-gray-900/10 pb-12 sm:space-y-0 sm:divide-y sm:divide-gray-900/10 sm:pb-0"
           >
-            <div class="sm:grid sm:grid-cols-[175px_auto_auto] sm:items-start sm:gap-4 sm:py-6">
+            <div
+              v-if="!isMediaUploadEnabled"
+              class="sm:grid sm:grid-cols-[175px_auto_auto] sm:items-start sm:gap-4 sm:py-6"
+            >
               <MediaSlug />
             </div>
 

--- a/client/src/modules/mediafiles/components/AssetsTable.vue
+++ b/client/src/modules/mediafiles/components/AssetsTable.vue
@@ -22,6 +22,12 @@
         <tbody class="divide-y divide-gray-200 bg-white">
           <tr v-for="file in files" :key="file.asset_id" :class="{ 'opacity-50': !file.enable }">
             <td class="relative px-7 sm:w-12 sm:px-6">
+              <div
+                v-if="file.is_verifying"
+                class="inline-flex items-center animate-pulse text-green-600 absolute left-[-14px] top-1/2 -mt-2.5"
+              >
+                <CloudIcon class="h-5 w-5" aria-hidden="true" />
+              </div>
               <input
                 type="checkbox"
                 class="absolute left-4 top-1/2 -mt-2 h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-600"
@@ -75,8 +81,6 @@ found" -->
                 class="inline-flex items-center rounded-md bg-white px-2.5 py-1.5 text-sm font-semibold text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-30 disabled:hover:bg-white"
                 @click="() => handleVerify(file.asset_id)"
               >
-                <!-- NEXT UP: display a pretty spinner instead, maybe around the checkbox -->
-                <div v-if="file.is_verifying">XXX</div>
                 {{ __('Verify') }}
               </button>
             </td>
@@ -100,6 +104,8 @@ import * as mediafiles from '@store/mediafiles.store'
 
 import { CheckCircleIcon, XCircleIcon } from '@heroicons/vue/solid'
 
+import { CloudIcon } from '@heroicons/vue/outline'
+
 import Timestamp from '@lib/timestamp'
 import AssetsEmptyState from './AssetsEmptyState.vue'
 
@@ -107,6 +113,7 @@ export default defineComponent({
   components: {
     CheckCircleIcon,
     XCircleIcon,
+    CloudIcon,
     AssetsEmptyState,
   },
 

--- a/client/src/modules/mediafiles/components/AssetsTable.vue
+++ b/client/src/modules/mediafiles/components/AssetsTable.vue
@@ -22,10 +22,6 @@
         <tbody class="divide-y divide-gray-200 bg-white">
           <tr v-for="file in files" :key="file.asset_id" :class="{ 'opacity-50': !file.enable }">
             <td class="relative px-7 sm:w-12 sm:px-6">
-              <!-- <div
-                  class="absolute inset-y-0 left-0 w-0.5"
-                  :class="{ 'bg-green-400': file.size > 0, 'bg-red-400': !file.size }"
-                ></div> -->
               <input
                 type="checkbox"
                 class="absolute left-4 top-1/2 -mt-2 h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-600"

--- a/client/src/modules/mediafiles/components/AssetsTable.vue
+++ b/client/src/modules/mediafiles/components/AssetsTable.vue
@@ -79,6 +79,8 @@ found" -->
                 class="inline-flex items-center rounded-md bg-white px-2.5 py-1.5 text-sm font-semibold text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-30 disabled:hover:bg-white"
                 @click="() => handleVerify(file.asset_id)"
               >
+                <!-- NEXT UP: display a pretty spinner instead, maybe around the checkbox -->
+                <div v-if="file.is_verifying">XXX</div>
                 {{ __('Verify') }}
               </button>
             </td>

--- a/client/src/modules/mediafiles/components/MediaUpload.vue
+++ b/client/src/modules/mediafiles/components/MediaUpload.vue
@@ -9,6 +9,7 @@
       <button
         type="button"
         class="relative block w-full rounded-lg border-2 border-dashed border-gray-300 p-12 text-center hover:border-gray-400 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2"
+        @click="uploadIntent"
       >
         <svg
           fill="none"
@@ -35,7 +36,7 @@ import { defineComponent } from 'vue'
 import { mapState, injectStore } from 'redux-vuex'
 
 import { selectors } from '@store'
-import { update as updateEpisode } from '@store/episode.store'
+import { uploadIntent } from '@store/mediafiles.store'
 
 export default defineComponent({
   setup() {
@@ -45,7 +46,11 @@ export default defineComponent({
     }
   },
 
-  methods: {},
+  methods: {
+    uploadIntent() {
+      this.dispatch(uploadIntent())
+    },
+  },
 
   computed: {},
 })

--- a/client/src/modules/mediafiles/components/MediaUpload.vue
+++ b/client/src/modules/mediafiles/components/MediaUpload.vue
@@ -1,0 +1,52 @@
+<template>
+  <label
+    for="mediafile_upload"
+    class="block text-sm font-medium leading-6 text-gray-900 sm:pt-1.5"
+    >{{ __('Upload') }}</label
+  >
+  <div class="mt-2 sm:col-span-2 sm:mt-0">
+    <div>
+      <button
+        type="button"
+        class="relative block w-full rounded-lg border-2 border-dashed border-gray-300 p-12 text-center hover:border-gray-400 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2"
+      >
+        <svg
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke-width="1.5"
+          stroke="currentColor"
+          class="mx-auto h-12 w-12 text-gray-400"
+        >
+          <path
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            d="M12 16.5V9.75m0 0l3 3m-3-3l-3 3M6.75 19.5a4.5 4.5 0 01-1.41-8.775 5.25 5.25 0 0110.233-2.33 3 3 0 013.758 3.848A3.752 3.752 0 0118 19.5H6.75z"
+          />
+        </svg>
+
+        <span class="mt-2 block text-sm font-semibold text-gray-900">Upload Media File</span>
+      </button>
+    </div>
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent } from 'vue'
+import { mapState, injectStore } from 'redux-vuex'
+
+import { selectors } from '@store'
+import { update as updateEpisode } from '@store/episode.store'
+
+export default defineComponent({
+  setup() {
+    return {
+      state: mapState({}),
+      dispatch: injectStore().dispatch,
+    }
+  },
+
+  methods: {},
+
+  computed: {},
+})
+</script>

--- a/client/src/modules/mediafiles/components/MediaUpload.vue
+++ b/client/src/modules/mediafiles/components/MediaUpload.vue
@@ -6,27 +6,10 @@
   >
   <div class="mt-2 sm:col-span-2 sm:mt-0">
     <div>
-      <button
-        type="button"
-        class="relative block w-full rounded-lg border-2 border-dashed border-gray-300 p-12 text-center hover:border-gray-400 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2"
-        @click="uploadIntent"
-      >
-        <svg
-          fill="none"
-          viewBox="0 0 24 24"
-          stroke-width="1.5"
-          stroke="currentColor"
-          class="mx-auto h-12 w-12 text-gray-400"
-        >
-          <path
-            stroke-linecap="round"
-            stroke-linejoin="round"
-            d="M12 16.5V9.75m0 0l3 3m-3-3l-3 3M6.75 19.5a4.5 4.5 0 01-1.41-8.775 5.25 5.25 0 0110.233-2.33 3 3 0 013.758 3.848A3.752 3.752 0 0118 19.5H6.75z"
-          />
-        </svg>
-
-        <span class="mt-2 block text-sm font-semibold text-gray-900">Upload Media File</span>
-      </button>
+      <podlove-button variant="primary" @click="uploadIntent" class="ml-1">
+        <upload-icon class="-ml-0.5 mr-2 h-4 w-4" aria-hidden="true" />
+        {{ __('Upload Media File') }}
+      </podlove-button>
     </div>
   </div>
 </template>
@@ -35,10 +18,15 @@
 import { defineComponent } from 'vue'
 import { mapState, injectStore } from 'redux-vuex'
 
-import { selectors } from '@store'
 import { uploadIntent } from '@store/mediafiles.store'
+import PodloveButton from '@components/button/Button.vue'
+import { UploadIcon } from '@heroicons/vue/outline'
 
 export default defineComponent({
+  components: {
+    PodloveButton,
+    UploadIcon,
+  },
   setup() {
     return {
       state: mapState({}),

--- a/client/src/sagas/chapters.sagas.ts
+++ b/client/src/sagas/chapters.sagas.ts
@@ -158,7 +158,7 @@ function* handleImport(action: { type: string; payload: string }) {
     parseMp4Chapters,
     parseAudacityChapters,
     parseHindeburgChapters,
-    parsePodloveChapters
+    parsePodloveChapters,
   ]
 
   let parsedChapters: PodloveChapter[] | null = []
@@ -221,7 +221,7 @@ function* handleKeydown(input: {
 }
 
 function* selectImageFromLibrary() {
-  yield put(wordpress.selectImageFromLibrary({ onSuccess: { type: chapters.SELECT_IMAGE } }))
+  yield put(wordpress.selectMediaFromLibrary({ onSuccess: { type: chapters.SELECT_IMAGE } }))
 }
 
 export default function () {

--- a/client/src/sagas/episode.sagas.ts
+++ b/client/src/sagas/episode.sagas.ts
@@ -66,7 +66,7 @@ function* save(api: PodloveApiClient, action: Action) {
 }
 
 function* selectImageFromLibrary() {
-  yield put(wordpress.selectImageFromLibrary({ onSuccess: { type: episode.SET_POSTER } }))
+  yield put(wordpress.selectMediaFromLibrary({ onSuccess: { type: episode.SET_POSTER } }))
 }
 
 function* updatePoster(action: Action) {

--- a/client/src/sagas/episode.sagas.ts
+++ b/client/src/sagas/episode.sagas.ts
@@ -18,7 +18,7 @@ function* episodeSaga(): any {
   yield fork(initialize, apiClient)
 
   yield takeEvery(episode.UPDATE, collectEpisodeUpdate)
-  yield debounce(3000, episode.UPDATE, save, apiClient)
+  yield debounce(1000, episode.UPDATE, save, apiClient)
   yield debounce(50, episode.QUICKSAVE, save, apiClient)
   yield takeEvery(episode.SELECT_POSTER, selectImageFromLibrary)
   yield takeEvery(episode.SET_POSTER, updatePoster)

--- a/client/src/sagas/episode.sagas.ts
+++ b/client/src/sagas/episode.sagas.ts
@@ -19,6 +19,7 @@ function* episodeSaga(): any {
 
   yield takeEvery(episode.UPDATE, collectEpisodeUpdate)
   yield debounce(3000, episode.UPDATE, save, apiClient)
+  yield debounce(50, episode.QUICKSAVE, save, apiClient)
   yield takeEvery(episode.SELECT_POSTER, selectImageFromLibrary)
   yield takeEvery(episode.SET_POSTER, updatePoster)
   yield takeEvery(episode.SET, updateAuphonicWebhookConfig)

--- a/client/src/sagas/mediafiles.sagas.ts
+++ b/client/src/sagas/mediafiles.sagas.ts
@@ -42,7 +42,7 @@ function* initialize(api: PodloveApiClient) {
 }
 
 function* selectMediaFromLibrary() {
-  yield put(wordpress.selectImageFromLibrary({ onSuccess: { type: mediafiles.SET_UPLOAD_URL } }))
+  yield put(wordpress.selectMediaFromLibrary({ onSuccess: { type: mediafiles.SET_UPLOAD_URL } }))
 }
 
 function* setUploadMedia(action: Action) {

--- a/client/src/sagas/mediafiles.sagas.ts
+++ b/client/src/sagas/mediafiles.sagas.ts
@@ -3,9 +3,12 @@ import { selectors } from '@store'
 import { all, call, delay, fork, put, select, takeEvery, throttle } from 'redux-saga/effects'
 import * as mediafiles from '@store/mediafiles.store'
 import * as episode from '@store/episode.store'
+import * as wordpress from '@store/wordpress.store'
 import { MediaFile } from '@store/mediafiles.store'
 import { takeFirst } from './helper'
 import { createApi } from './api'
+import { Action } from 'redux'
+import { get } from 'lodash'
 
 function* mediafilesSaga(): any {
   const apiClient: PodloveApiClient = yield createApi()
@@ -32,8 +35,20 @@ function* initialize(api: PodloveApiClient) {
     maybeUpdateDuration,
     api
   )
+  yield takeEvery(mediafiles.UPLOAD_INTENT, selectMediaFromLibrary)
+  yield takeEvery(mediafiles.SET_UPLOAD_URL, setUploadMedia)
 
   yield put(mediafiles.initDone())
+}
+
+function* selectMediaFromLibrary() {
+  yield put(wordpress.selectImageFromLibrary({ onSuccess: { type: mediafiles.SET_UPLOAD_URL } }))
+}
+
+function* setUploadMedia(action: Action) {
+  const url = get(action, ['payload'])
+
+  console.log('setUploadMedia', url)
 }
 
 function* maybeUpdateDuration(api: PodloveApiClient) {

--- a/client/src/sagas/mediafiles.sagas.ts
+++ b/client/src/sagas/mediafiles.sagas.ts
@@ -104,12 +104,20 @@ function* maybeReverify(api: PodloveApiClient, action: { type: string; payload: 
 }
 
 function* verifyEpisodeAsset(api: PodloveApiClient, episodeId: number, assetId: number) {
+  yield put(
+    mediafiles.update({
+      asset_id: assetId,
+      is_verifying: true,
+    })
+  )
+
   const { result } = yield api.put(`episodes/${episodeId}/media/${assetId}/verify`, {})
 
   const fileUpdate: Partial<MediaFile> = {
     asset_id: assetId,
     url: result.file_url,
     size: result.file_size,
+    is_verifying: false,
   }
 
   yield put(mediafiles.update(fileUpdate))

--- a/client/src/sagas/mediafiles.sagas.ts
+++ b/client/src/sagas/mediafiles.sagas.ts
@@ -50,7 +50,6 @@ function* setUploadMedia(action: Action) {
   const slug = url.split('\\').pop().split('/').pop().split('.').shift()
 
   yield put(episode.update({ prop: 'slug', value: slug }))
-  // TODO: can we get away with hiding the slug UI? it's filled automatically anyway!
   // TODO: add indicator that assets are refreshing after slug change (any, not just here)
   // FIXME: enable asset that was just uploaded once it's green
 }

--- a/client/src/sagas/mediafiles.sagas.ts
+++ b/client/src/sagas/mediafiles.sagas.ts
@@ -50,6 +50,9 @@ function* setUploadMedia(action: Action) {
   const slug = url.split('\\').pop().split('/').pop().split('.').shift()
 
   yield put(episode.update({ prop: 'slug', value: slug }))
+  // TODO: can we get away with hiding the slug UI? it's filled automatically anyway!
+  // TODO: add indicator that assets are refreshing after slug change (any, not just here)
+  // FIXME: enable asset that was just uploaded once it's green
 }
 
 function* maybeUpdateDuration(api: PodloveApiClient) {

--- a/client/src/sagas/mediafiles.sagas.ts
+++ b/client/src/sagas/mediafiles.sagas.ts
@@ -47,8 +47,9 @@ function* selectMediaFromLibrary() {
 
 function* setUploadMedia(action: Action) {
   const url = get(action, ['payload'])
+  const slug = url.split('\\').pop().split('/').pop().split('.').shift()
 
-  console.log('setUploadMedia', url)
+  yield put(episode.update({ prop: 'slug', value: slug }))
 }
 
 function* maybeUpdateDuration(api: PodloveApiClient) {

--- a/client/src/sagas/mediafiles.sagas.ts
+++ b/client/src/sagas/mediafiles.sagas.ts
@@ -51,8 +51,6 @@ function* setUploadMedia(action: Action) {
 
   yield put(episode.update({ prop: 'slug', value: slug }))
   yield put(episode.quicksave())
-  // TODO: add indicator that assets are refreshing after slug change (any, not just here)
-  // FIXME: enable asset that was just uploaded once it's green
 }
 
 function* maybeUpdateDuration(api: PodloveApiClient) {

--- a/client/src/sagas/mediafiles.sagas.ts
+++ b/client/src/sagas/mediafiles.sagas.ts
@@ -50,6 +50,7 @@ function* setUploadMedia(action: Action) {
   const slug = url.split('\\').pop().split('/').pop().split('.').shift()
 
   yield put(episode.update({ prop: 'slug', value: slug }))
+  yield put(episode.quicksave())
   // TODO: add indicator that assets are refreshing after slug change (any, not just here)
   // FIXME: enable asset that was just uploaded once it's green
 }

--- a/client/src/sagas/wordpress.sagas.ts
+++ b/client/src/sagas/wordpress.sagas.ts
@@ -28,7 +28,7 @@ function* wordpressSaga(): any {
   }
 
   if (wordpress.media) {
-    yield takeEvery(wordpressStore.SELECT_IMAGE_FROM_LIBRARY as any, selectImageFromLibrary)
+    yield takeEvery(wordpressStore.SELECT_IMAGE_FROM_LIBRARY as any, selectMediaFromLibrary)
   }
 }
 
@@ -75,8 +75,7 @@ function* updatePostTitle() {
     .replace('%episode_title%', title || '')
 }
 
-// TODO: refactor/rename as it's not only used for images
-function* selectImageFromLibrary(action: { payload: { onSuccess: Action } }) {
+function* selectMediaFromLibrary(action: { payload: { onSuccess: Action } }) {
   const successAction = get(action, ['payload', 'onSuccess'])
 
   if (!successAction) {

--- a/client/src/sagas/wordpress.sagas.ts
+++ b/client/src/sagas/wordpress.sagas.ts
@@ -75,6 +75,7 @@ function* updatePostTitle() {
     .replace('%episode_title%', title || '')
 }
 
+// TODO: refactor/rename as it's not only used for images
 function* selectImageFromLibrary(action: { payload: { onSuccess: Action } }) {
   const successAction = get(action, ['payload', 'onSuccess'])
 

--- a/client/src/store/episode.store.ts
+++ b/client/src/store/episode.store.ts
@@ -9,6 +9,7 @@ import { arrayMove } from '@lib/array'
 
 export const INIT = 'podlove/publisher/episode/INIT'
 export const UPDATE = 'podlove/publisher/episode/UPDATE'
+export const QUICKSAVE = 'podlove/publisher/episode/QUICKSAVE'
 export const SAVED = 'podlove/publisher/episode/SAVED'
 export const SET = 'podlove/publisher/episode/SET'
 export const SET_POSTER = 'podlove/publisher/episode/SET_POSTER'
@@ -57,6 +58,7 @@ export const initialState: State = {
 }
 
 export const update = createAction<{ prop: string; value: any }>(UPDATE)
+export const quicksave = createAction<void>(QUICKSAVE)
 export const init = createAction<void>(INIT)
 export const selectPoster = createAction<void>(SELECT_POSTER)
 export const set = createAction<{

--- a/client/src/store/mediafiles.store.ts
+++ b/client/src/store/mediafiles.store.ts
@@ -7,6 +7,7 @@ export type MediaFile = {
   url: string
   size: number
   enable: boolean
+  is_verifying: boolean
 }
 
 export type State = {
@@ -54,7 +55,7 @@ export const reducer = handleActions(
     [UPDATE]: (state: State, action: { type: string; payload: Partial<MediaFile> }): State => ({
       ...state,
       files: state.files.reduce(
-        (result: MediaFiles[], file) => [
+        (result: MediaFile[], file) => [
           ...result,
           file.asset_id == action.payload.asset_id ? { ...file, ...action.payload } : file,
         ],
@@ -64,7 +65,7 @@ export const reducer = handleActions(
     [ENABLE]: (state: State, action: { type: string; payload: number }): State => ({
       ...state,
       files: state.files.reduce(
-        (result: MediaFiles[], file) => [
+        (result: MediaFile[], file) => [
           ...result,
           file.asset_id == action.payload ? { ...file, enable: true } : file,
         ],
@@ -74,7 +75,7 @@ export const reducer = handleActions(
     [DISABLE]: (state: State, action: { type: string; payload: number }): State => ({
       ...state,
       files: state.files.reduce(
-        (result: MediaFiles[], file) => [
+        (result: MediaFile[], file) => [
           ...result,
           file.asset_id == action.payload ? { ...file, enable: false } : file,
         ],

--- a/client/src/store/mediafiles.store.ts
+++ b/client/src/store/mediafiles.store.ts
@@ -1,5 +1,4 @@
 import { createAction, handleActions } from 'redux-actions'
-import MediaFiles from 'src/modules/mediafiles'
 
 export type MediaFile = {
   asset_id: number

--- a/client/src/store/mediafiles.store.ts
+++ b/client/src/store/mediafiles.store.ts
@@ -26,7 +26,6 @@ export const UPDATE = 'podlove/publisher/mediafiles/UPDATE'
 export const ENABLE = 'podlove/publisher/mediafiles/ENABLE'
 export const DISABLE = 'podlove/publisher/mediafiles/DISABLE'
 export const VERIFY = 'podlove/publisher/mediafiles/VERIFY'
-// TODO: rename? because it's "select or upload"
 export const UPLOAD_INTENT = 'podlove/publisher/mediafiles/UPLOAD_INTENT'
 export const SET_UPLOAD_URL = 'podlove/publisher/mediafiles/SET_UPLOAD_URL'
 

--- a/client/src/store/mediafiles.store.ts
+++ b/client/src/store/mediafiles.store.ts
@@ -26,6 +26,9 @@ export const UPDATE = 'podlove/publisher/mediafiles/UPDATE'
 export const ENABLE = 'podlove/publisher/mediafiles/ENABLE'
 export const DISABLE = 'podlove/publisher/mediafiles/DISABLE'
 export const VERIFY = 'podlove/publisher/mediafiles/VERIFY'
+// TODO: rename? because it's "select or upload"
+export const UPLOAD_INTENT = 'podlove/publisher/mediafiles/UPLOAD_INTENT'
+export const SET_UPLOAD_URL = 'podlove/publisher/mediafiles/SET_UPLOAD_URL'
 
 export const init = createAction<void>(INIT)
 export const initDone = createAction<void>(INIT_DONE)
@@ -34,6 +37,8 @@ export const update = createAction<Partial<MediaFile>>(UPDATE)
 export const enable = createAction<number>(ENABLE)
 export const disable = createAction<number>(DISABLE)
 export const verify = createAction<number>(VERIFY)
+export const uploadIntent = createAction<void>(UPLOAD_INTENT)
+export const setUploadUrl = createAction<string>(SET_UPLOAD_URL)
 
 // TODO: enable revalidates I think?
 export const reducer = handleActions(

--- a/client/src/store/selectors.ts
+++ b/client/src/store/selectors.ts
@@ -133,6 +133,7 @@ const settings = {
     root.settings,
     settingsStore.selectors.enableEpisodeExplicit
   ),
+  modules: createSelector(root.settings, settingsStore.selectors.modules),
 }
 
 export default {

--- a/client/src/store/settings.store.ts
+++ b/client/src/store/settings.store.ts
@@ -38,6 +38,7 @@ export interface State {
   media: {
     base_uri: null | string
   }
+  modules: string[]
 }
 
 export const initialState: State = {
@@ -73,6 +74,7 @@ export const initialState: State = {
   media: {
     base_uri: null,
   },
+  modules: [],
 }
 
 const normalizeAssignmentImage = (
@@ -184,6 +186,7 @@ export const reducer = handleActions(
         ),
         transcript: get(action, ['payload', 'assignments', 'transcript'], null),
       },
+      modules: get(action, ['payload', 'modules']),
     }),
   },
   initialState
@@ -196,4 +199,5 @@ export const selectors = {
   imageAsset: (state: State) => state.assets.image,
   enableEpisodeExplicit: (state: State) => state.metadata.enable_episode_explicit,
   mediaFileBaseUri: (state: State) => state.media.base_uri,
+  modules: (state: State) => state.modules,
 }

--- a/client/src/store/wordpress.store.ts
+++ b/client/src/store/wordpress.store.ts
@@ -1,8 +1,8 @@
-import { Action } from 'redux';
+import { Action } from 'redux'
 import { createAction } from 'redux-actions'
 
 export const UPDATE = 'podlove/publisher/wordpress/UPDATE'
-export const SELECT_IMAGE_FROM_LIBRARY = 'podlove/publisher/wordpress/SELECT_IMAGE_FROM_LIBRARY'
+export const SELECT_MEDIA_FROM_LIBRARY = 'podlove/publisher/wordpress/SELECT_MEDIA_FROM_LIBRARY'
 
-export const update = createAction<{ prop: string; value: any; }>(UPDATE)
-export const selectImageFromLibrary = createAction<{ onSuccess: Action }>(SELECT_IMAGE_FROM_LIBRARY)
+export const update = createAction<{ prop: string; value: any }>(UPDATE)
+export const selectMediaFromLibrary = createAction<{ onSuccess: Action }>(SELECT_MEDIA_FROM_LIBRARY)

--- a/includes/podlove_data_js_adapter.php
+++ b/includes/podlove_data_js_adapter.php
@@ -51,6 +51,7 @@ function podlove_js_adapter_inject_settings($data)
     }, []);
 
     $data['media'] = ['base_uri' => $podcast->get_media_file_base_uri()];
+    $data['modules'] = \Podlove\Modules\Base::get_active_module_names();
 
     return $data;
 }

--- a/lib/modules/wordpress_file_upload/wordpress_file_upload.php
+++ b/lib/modules/wordpress_file_upload/wordpress_file_upload.php
@@ -51,8 +51,6 @@ class Wordpress_File_Upload extends \Podlove\Modules\Base
     public function register_hooks()
     {
         add_filter('upload_dir', [$this, 'custom_media_upload_dir']);
-        add_filter('podlove_episode_form_data', [$this, 'add_upload_button_to_form']);
-        add_action('podlove_episode_meta_box_end', [$this, 'add_upload_button_styles_and_scripts']);
         add_filter('podlove_media_file_base_uri_form', [$this, 'set_form_placeholder']);
         add_filter('podlove_media_file_base_uri', [$this, 'set_media_file_base_uri']);
     }
@@ -79,24 +77,6 @@ class Wordpress_File_Upload extends \Podlove\Modules\Base
         return $config;
     }
 
-    public function add_upload_button_to_form($form_data)
-    {
-        $form_data[] = [
-            'type' => 'upload',
-            'key' => 'file_upload',
-            'options' => [
-                'label' => __('File Upload', 'podlove-podcasting-plugin-for-wordpress'),
-                'media_title' => __('Media File', 'podlove-podcasting-plugin-for-wordpress'),
-                'media_button_text' => __('Use Media File', 'podlove-podcasting-plugin-for-wordpress'),
-                'form_button_text' => __('Upload Media File', 'podlove-podcasting-plugin-for-wordpress'),
-                'allow_multi_upload' => false
-            ],
-            'position' => 512,
-        ];
-
-        return $form_data;
-    }
-
     /**
      * Override upload_dir so it ignores date subdirectories etc.
      *
@@ -118,32 +98,6 @@ class Wordpress_File_Upload extends \Podlove\Modules\Base
         $upload['url'] = $upload['baseurl'].$upload['subdir'];
 
         return $upload;
-    }
-
-    public function add_upload_button_styles_and_scripts()
-    {
-        ?>
-        <style>
-        #_podlove_meta_file_upload,
-        .podlove-media-upload-wrap .podlove_preview_pic,
-        .podlove-media-upload-wrap p
-        {
-        display: none !important;
-        }
-        </style>
-        <script>
-        const uploadUrlInput = document.getElementById('_podlove_meta_file_upload')
-        const slugInput = document.getElementById('_podlove_meta_slug');
-
-        uploadUrlInput.addEventListener('change', function (e) {
-            const value = e.target.value;
-            const slug = value.split('\\').pop().split('/').pop().split('.').shift()
-
-            slugInput.value = slug;
-            slugInput.dispatchEvent(new Event('slugHasChanged', { 'bubbles': true }))
-        });
-        </script>
-    <?php
     }
 
     private function get_subdir()

--- a/lib/modules/wordpress_file_upload/wordpress_file_upload.php
+++ b/lib/modules/wordpress_file_upload/wordpress_file_upload.php
@@ -7,7 +7,7 @@ class Wordpress_File_Upload extends \Podlove\Modules\Base
     const DEFAULT_DIR = '/podlove-media';
 
     protected $module_name = 'WordPress File Upload';
-    protected $module_description = 'If you want to upload you media files to WordPress, this module adds a button to the episode form to do that.';
+    protected $module_description = 'If you want to upload your media files to WordPress, this module adds a button to the episode form to do that.';
     protected $module_group = 'system';
 
     public function load()


### PR DESCRIPTION
Continuation of #1368

Some tweaks that made it feel snappy:

- added a "quicksave" event so I can trigger episode save without waiting for the debounce
- display verification indicator
- auto-enable asset on verification

Also I'm hiding the slug input in upload mode because I think it's not necessary here.

https://github.com/podlove/podlove-publisher/assets/235918/6e6e9509-e864-4792-a4bd-94bcdfcf17c7

## TODO

- [x] Renaming, maybe (see code comments in diff)
- [x] Update API docs (see https://github.com/podlove/podlove-publisher/pull/1368#issuecomment-1546943649)