### PR TITLE
fix: format specifier

### DIFF
--- a/lib/settings/support.php
+++ b/lib/settings/support.php
@@ -54,7 +54,7 @@ class Support
 					</li>
 					<li>
 						<?php echo sprintf(
-						    __('For quick remarks and feedback, you can reach us at %Mastodon (fosstodon.org/@podlove)%s', 'podlove-podcasting-plugin-for-wordpress'),
+						    __('For quick remarks and feedback, you can reach us at %sMastodon (fosstodon.org/@podlove)%s', 'podlove-podcasting-plugin-for-wordpress'),
 						    '<a target="_blank" href="https://fosstodon.org/@podlove">',
 						    '</a>'
 						); ?>


### PR DESCRIPTION
Commit a722d451b99dc3c2a160079e40dc23e4b2063632 inadvertantly removed the format specifier, causing the support page to crash due to unknown format specifier `%M`.

This PR restores the format specifier.