### PR TITLE
Make File Types readonly

### DIFF
--- a/lib/file_type_list_table.php
+++ b/lib/file_type_list_table.php
@@ -18,31 +18,7 @@ class File_Type_List_Table extends \Podlove\List_Table
 
     public function column_name($file_type)
     {
-        $actions = [
-            'edit' => sprintf(
-                '<a href="?page=%s&podlove_tab=%s&action=%s&file_type=%s">'.__('Edit', 'podlove-podcasting-plugin-for-wordpress').'</a>',
-                htmlspecialchars($_REQUEST['page'] ?? ''),
-                htmlspecialchars($_REQUEST['podlove_tab'] ?? ''),
-                'edit',
-                $file_type->id
-            ),
-            'delete' => sprintf(
-                '<a href="?page=%s&podlove_tab=%s&action=%s&file_type=%s&_podlove_nonce=%s">'.__('Delete', 'podlove-podcasting-plugin-for-wordpress').'</a>',
-                htmlspecialchars($_REQUEST['page'] ?? ''),
-                htmlspecialchars($_REQUEST['podlove_tab'] ?? ''),
-                'delete',
-                $file_type->id,
-                wp_create_nonce('update_file_type')
-            ),
-        ];
-
-        return sprintf(
-            '%1$s %2$s',
-            // $1%s
-            $file_type->name,
-            // $3%s
-            $this->row_actions($actions)
-        );
+        return $file_type->name;
     }
 
     public function column_id($file_type)

--- a/lib/settings/file_type.php
+++ b/lib/settings/file_type.php
@@ -8,122 +8,15 @@ class FileType
 
     private static $nonce = 'update_file_type';
 
-    public function __construct($handle)
-    {
-        add_action('admin_init', [$this, 'process_form']);
-    }
-
-    public function process_form()
-    {
-        $action = (isset($_REQUEST['action'])) ? $_REQUEST['action'] : null;
-
-        if (!in_array($action, ['save', 'create', 'delete'])) {
-            return;
-        }
-
-        if (!wp_verify_nonce($_REQUEST['_podlove_nonce'], self::$nonce)) {
-            return;
-        }
-
-        if ($action === 'save') {
-            $this->save();
-        } elseif ($action === 'create') {
-            $this->create();
-        } elseif ($action === 'delete') {
-            $this->delete();
-        }
-    }
+    public function __construct() {}
 
     public function page()
     {
         ?>
 		<div class="wrap">
-			<?php
-            $action = (isset($_REQUEST['action'])) ? $_REQUEST['action'] : null;
-        switch ($action) {
-            case 'new':
-                $this->new_template();
-
-                break;
-            case 'edit':
-                $this->edit_template();
-
-                break;
-            case 'index':
-            default:
-                $this->view_template();
-
-                break;
-        } ?>
+			<?php $this->view_template(); ?>
 		</div>
 		<?php
-    }
-
-    /**
-     * Process form: save/update a format.
-     */
-    private function save()
-    {
-        if (!isset($_REQUEST['file_type'])) {
-            return;
-        }
-
-        $format = \Podlove\Model\FileType::find_by_id($_REQUEST['file_type']);
-
-        if (!isset($_POST['podlove_file_type']) || !is_array($_POST['podlove_file_type'])) {
-            return;
-        }
-
-        foreach ($_POST['podlove_file_type'] as $key => $value) {
-            $value = trim($value);
-            $value = $key === 'extension' ? trim($value, '.') : $value;
-            $format->{$key} = $value;
-        }
-
-        $format->save();
-
-        if (isset($_POST['submit_and_stay'])) {
-            $this->redirect('edit', $format->id);
-        } else {
-            $this->redirect('index', $format->id);
-        }
-    }
-
-    /**
-     * Process form: create a format.
-     */
-    private function create()
-    {
-        $format = new \Podlove\Model\FileType();
-
-        if (!isset($_POST['podlove_file_type']) || !is_array($_POST['podlove_file_type'])) {
-            return;
-        }
-
-        foreach ($_POST['podlove_file_type'] as $key => $value) {
-            $format->{$key} = $value;
-        }
-        $format->save();
-
-        if (isset($_POST['submit_and_stay'])) {
-            $this->redirect('edit', $format->id);
-        } else {
-            $this->redirect('index');
-        }
-    }
-
-    /**
-     * Process form: delete a format.
-     */
-    private function delete()
-    {
-        if (!isset($_REQUEST['file_type'])) {
-            return;
-        }
-
-        \Podlove\Model\FileType::find_by_id($_REQUEST['file_type'])->delete();
-
-        $this->redirect('index');
     }
 
     /**
@@ -142,85 +35,15 @@ class FileType
         exit;
     }
 
-    private function new_template()
-    {
-        $format = new \Podlove\Model\FileType(); ?>
-		<h3><?php echo __('Add New File Type', 'podlove-podcasting-plugin-for-wordpress'); ?></h3>
-		<?php
-        $this->form_template($format, 'create', __('Add New Format', 'podlove-podcasting-plugin-for-wordpress'));
-    }
-
     private function view_template()
     {
         ?>
-		<h2>
-			<a href="?page=<?php echo htmlspecialchars($_REQUEST['page'] ?? ''); ?>&amp;podlove_tab=<?php echo htmlspecialchars($_REQUEST['podlove_tab'] ?? ''); ?>&amp;action=new" class="add-new-h2"><?php echo __('Add New', 'podlove-podcasting-plugin-for-wordpress'); ?></a>
-		</h2>
 		<p>
-			<?php echo __('This is a list of all file types Podlove Publisher knows about. If you would like to serve assets of an unknown file type, you must add it here before you can create the asset.', 'podlove-podcasting-plugin-for-wordpress'); ?>
+			<?php echo __('This is a list of all file types Podlove Publisher knows about.', 'podlove-podcasting-plugin-for-wordpress'); ?>
 		</p>
 		<?php
         $table = new \Podlove\File_Type_List_Table();
         $table->prepare_items();
         $table->display();
-    }
-
-    private function form_template($format, $action, $button_text = null)
-    {
-        $form_args = [
-            'context' => 'podlove_file_type',
-            'hidden' => [
-                'file_type' => $format->id,
-                'action' => $action,
-                'podlove_tab' => htmlspecialchars($_REQUEST['podlove_tab'] ?? ''),
-            ],
-            'submit_button' => false, // for custom control in form_end
-            'form_end' => function () {
-                echo '<p>';
-                submit_button(__('Save Changes'), 'primary', 'submit', false);
-                echo ' ';
-                submit_button(__('Save Changes and Continue Editing', 'podlove-podcasting-plugin-for-wordpress'), 'secondary', 'submit_and_stay', false);
-                echo '</p>';
-            },
-            'nonce' => self::$nonce
-        ];
-
-        \Podlove\Form\build_for($format, $form_args, function ($form) {
-            $wrapper = new \Podlove\Form\Input\TableWrapper($form);
-
-            $types = [];
-            foreach (\Podlove\Model\FileType::get_types() as $type) {
-                $types[$type] = $type;
-            }
-
-            $wrapper->string('name', [
-                'label' => __('Name', 'podlove-podcasting-plugin-for-wordpress'),
-                'html' => ['class' => 'podlove-check-input'],
-                'description' => '', ]);
-
-            $wrapper->select('type', [
-                'label' => __('Document Type', 'podlove-podcasting-plugin-for-wordpress'),
-                'options' => $types,
-            ]);
-
-            $wrapper->string('mime_type', [
-                'label' => __('Format Mime Type', 'podlove-podcasting-plugin-for-wordpress'),
-                'html' => ['class' => 'podlove-check-input'],
-                'description' => __('Example: audio/mp4', 'podlove-podcasting-plugin-for-wordpress'), ]);
-
-            $wrapper->string('extension', [
-                'label' => __('Format Extension', 'podlove-podcasting-plugin-for-wordpress'),
-                'html' => ['class' => 'podlove-check-input'],
-                'description' => __('Example: m4a', 'podlove-podcasting-plugin-for-wordpress'), ]);
-        });
-    }
-
-    private function edit_template()
-    {
-        $format = \Podlove\Model\FileType::find_by_id($_REQUEST['file_type']); ?>
-		<h3><?php echo __('Edit File Type', 'podlove-podcasting-plugin-for-wordpress'); ?>: <?php echo $format->name; ?></h3>
-
-		<?php $this->form_template($format, 'save'); ?>
-		<?php
     }
 }

--- a/readme.txt
+++ b/readme.txt
@@ -104,6 +104,10 @@ This product includes GeoLite2 data created by MaxMind, available from http://ww
 
 == Changelog ==
 
+= 2023-11-01 =
+
+* Expert Settings: "File Types" are now readonly
+
 = 2023-10-20 =
 
 * merge back all changes from main branch (3.8.x releases)


### PR DESCRIPTION
Follwing a discussion on Discord (https://discord.com/channels/726154142980243459/898908411356393552/1166796792025858078), here's the suggestion to make file types readonly. It's a pre requirement for us eventually doing more with them (adding mime type and other metadata) and presumably affects less than a hand full of people.