### PR TITLE
fix(contributor) - Set group for episode contributor

### DIFF
--- a/client/src/sagas/contributors.sagas.ts
+++ b/client/src/sagas/contributors.sagas.ts
@@ -67,8 +67,8 @@ function* updateEpisodeContributions(api: PodloveApiClient) {
   let contributors = data.map(function ({ contributor_id, role_id, group_id, position, comment }) {
     return {
       contributor_id: toInteger(contributor_id),
-      role_id: toInteger(role_id) == 0 && roles.length > 0 ? 1 : toInteger(role_id),
-      group_id: toInteger(group_id) == 0 && groups.length > 0 ? 1 : toInteger(group_id),
+      role_id: toInteger(role_id) == 0 && roles.length > 0 ? roles[0].id : toInteger(role_id),
+      group_id: toInteger(group_id) == 0 && groups.length > 0 ? groups[0].id : toInteger(group_id),
       position: toInteger(position),
       comment: comment || ''
     }


### PR DESCRIPTION
If the list of roles and groups for the contributors is not empty, the first entry must be selected. The first entry don't have always ID 1. Use the Id from the first entry in the list.