### PR TITLE
fix(build): delete all vendor prefixed directories

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,13 +59,7 @@ client_next:
 client: client_legacy client_next
 
 build:
-	mkdir -p vendor-prefixed
-	composer install --no-progress --prefer-dist --optimize-autoloader --no-dev
-	composer prefix-dependencies
-	rm -rf vendor/piwik
-	rm -rf vendor/twig
-	composer dump-autoload --classmap-authoritative
-	# client
+	make composer_with_prefixing
 	make client
 
 	rm -rf dist/*


### PR DESCRIPTION
by simply using `make composer_with_prefixing` instead of the old, inaccurate copy pasted version of it.

Specifically fixes an incompatibility with woocommerce.