### PR TITLE
Ensure `trim()` is called with correct argument type.

### DIFF
--- a/lib/feeds/base.php
+++ b/lib/feeds/base.php
@@ -10,18 +10,16 @@ function get_description()
 
     $episode = \Podlove\Model\Episode::find_one_by_post_id($post->ID);
 
-    $summary = trim($episode->summary);
-    $subtitle = trim($episode->subtitle);
-    $title = trim($post->post_title);
+    $summary = trim($episode->summary ?? '');
+    $subtitle = trim($episode->subtitle ?? '');
+    $title = trim($post->post_title ?? '');
 
-    $description = '';
+    $description = $title;
 
-    if (strlen($summary)) {
+    if (strlen($summary) > 0) {
         $description = $summary;
-    } elseif (strlen($subtitle)) {
+    } elseif (strlen($subtitle) > 0) {
         $description = $subtitle;
-    } else {
-        $description = $title;
     }
 
     return apply_filters('podlove_feed_item_description', html_entity_decode($description));


### PR DESCRIPTION
This commit fixes "deprecated" notices which are thrown for each episode in the feed when certain fields are empty (`null`):

```
PHP Deprecated: trim(): Passing null to parameter #1 ($string) of type string is deprecated in /app/wp-content/plugins/podlove-podcasting-plugin-for-wordpress/lib/feeds/base.php on line 13
PHP Deprecated: trim(): Passing null to parameter #1 ($string) of type string is deprecated in /app/wp-content/plugins/podlove-podcasting-plugin-for-wordpress/lib/feeds/base.php on line 14
```

Also removes one branch from the condition which fills `$description`.