### PR TITLE
Fixed broken link to templates guide

### DIFF
--- a/lib/settings/templates.php
+++ b/lib/settings/templates.php
@@ -87,7 +87,7 @@ $this->view_template(); ?>
             '</a>',
             '<a href="http://docs.podlove.org/reference/template-tags/" target="_blank">',
             '</a>',
-            '<a href="http://docs.podlove.org/guides/understanding-templates/" target="_blank">',
+            '<a href="http://docs.podlove.org/guides/templates/" target="_blank">',
             '</a>'
         ); ?>
 		<div id="template-editor">


### PR DESCRIPTION
Broken link: https://docs.podlove.org/podlove-publisher/guides/understanding-templates/ 
Correct link: https://docs.podlove.org/podlove-publisher/guides/templates/

I made the same change over here: https://github.com/podlove/documentation/pull/39