### PR TITLE
fix(episode) - Remove old save code for license and explicit

### DIFF
--- a/includes/explicit_content.php
+++ b/includes/explicit_content.php
@@ -20,9 +20,3 @@ add_filter('podlove_episode_form_data', function ($form_data) {
 
     return $form_data;
 });
-
-add_filter('podlove_episode_data_filter', function ($filter) {
-    return array_merge($filter, [
-        'explicit' => FILTER_UNSAFE_RAW,
-    ]);
-});

--- a/includes/license.php
+++ b/includes/license.php
@@ -29,9 +29,3 @@ function podlove_episode_license_extend_form($form_data, $episode)
     return $form_data;
 }
 
-add_filter('podlove_episode_data_filter', function ($filter) {
-    return array_merge($filter, [
-        'license_name' => FILTER_UNSAFE_RAW,
-        'license_url' => FILTER_SANITIZE_URL,
-    ]);
-});


### PR DESCRIPTION
Dieser Commit löst das Problem (https://community.podlove.org/t/license-and-explicit-warning-are-not-saved/3311) 

Beim Speichern der Episoden-Seite wurde die Lizenz und das Explicit-Flag überschrieben.