### PR TITLE
Spike: Transcript voice selection rework

### DIFF
--- a/client/src/modules/transcripts/components/List.vue
+++ b/client/src/modules/transcripts/components/List.vue
@@ -35,8 +35,12 @@
   <div v-else class="text-center h-96 flex items-center justify-center flex-col">
     <document-text-icon class="mx-auto h-12 w-12 text-gray-400" />
 
-    <h3 class="mt-2 text-sm font-medium text-gray-900">{{ __('No transcript yet', 'podlove-podcasting-plugin-for-wordpress') }}</h3>
-    <p class="mt-1 text-sm text-gray-500">{{ __('Get started by importing a transcript.', 'podlove-podcasting-plugin-for-wordpress') }}</p>
+    <h3 class="mt-2 text-sm font-medium text-gray-900">
+      {{ __('No transcript yet', 'podlove-podcasting-plugin-for-wordpress') }}
+    </h3>
+    <p class="mt-1 text-sm text-gray-500">
+      {{ __('Get started by importing a transcript.', 'podlove-podcasting-plugin-for-wordpress') }}
+    </p>
     <div class="mt-6">
       <transcripts-import outlet="content" class="mr-1" />
     </div>
@@ -149,6 +153,13 @@ export default defineComponent({
           ...transcript,
           voice: get(this.voices, [transcript.voiceId], { name: transcript.voiceId }),
         }))
+        .filter((transcript: Transcript) => {
+          const assignment = this.state.voices.find(
+            (voice: { voice: string; contributor: string }) => voice.voice == transcript.voiceId
+          )
+
+          return assignment.contributor != 4294967295
+        })
     },
   },
 

--- a/client/src/modules/transcripts/components/Voices.vue
+++ b/client/src/modules/transcripts/components/Voices.vue
@@ -23,7 +23,12 @@
           class="mt-1 block w-full py-2 px-3 border border-gray-300 bg-white rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm"
           @change="updateContributor(voice.voice, $event)"
         >
-          <option value="0"></option>
+          <option value="4294967295">
+            [{{ __('hide from transcript', 'podlove-podcasting-plugin-for-wordpress') }}]
+          </option>
+          <option value="0">
+            {{ voice.voice }} ({{ __('plain text', 'podlove-podcasting-plugin-for-wordpress') }})
+          </option>
           <option
             v-for="(contributor, kindex) in sortedContributors"
             :key="`voice-${vindex}-contributor-${kindex}`"

--- a/client/src/modules/transcripts/components/Voices.vue
+++ b/client/src/modules/transcripts/components/Voices.vue
@@ -1,9 +1,13 @@
 <template>
   <div v-if="state.voices.length > 0">
-    <podlove-button variant="secondary" size="small" @click="openVoices()">{{ __('Voices', 'podlove-podcasting-plugin-for-wordpress') }}</podlove-button>
+    <podlove-button variant="secondary" size="small" @click="openVoices()">{{
+      __('Voices', 'podlove-podcasting-plugin-for-wordpress')
+    }}</podlove-button>
     <modal :open="modalOpen" @close="closeVoices()">
       <div class="border-gray-200 border-b pb-2 px-4 -mx-6 mb-4">
-        <h3 class="text-lg leading-6 font-medium text-gray-900">{{ __('Transcript Voices', 'podlove-podcasting-plugin-for-wordpress') }}</h3>
+        <h3 class="text-lg leading-6 font-medium text-gray-900">
+          {{ __('Transcript Voices', 'podlove-podcasting-plugin-for-wordpress') }}
+        </h3>
       </div>
       <div
         v-for="(voice, vindex) in state.voices"
@@ -16,24 +20,12 @@
         }}</label>
         <select
           :value="voice.contributor"
-          class="
-            mt-1
-            block
-            w-full
-            py-2
-            px-3
-            border border-gray-300
-            bg-white
-            rounded-md
-            shadow-sm
-            focus:outline-none focus:ring-indigo-500 focus:border-indigo-500
-            sm:text-sm
-          "
+          class="mt-1 block w-full py-2 px-3 border border-gray-300 bg-white rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm"
           @change="updateContributor(voice.voice, $event)"
         >
           <option value="0"></option>
           <option
-            v-for="(contributor, kindex) in state.contributors"
+            v-for="(contributor, kindex) in sortedContributors"
             :key="`voice-${vindex}-contributor-${kindex}`"
             :value="contributor.id"
           >
@@ -52,6 +44,7 @@ import selectors from '@store/selectors'
 import { updateVoice } from '@store/transcripts.store'
 import Modal from '@components/modal/Modal.vue'
 import PodloveButton from '@components/button/Button.vue'
+import { PodloveContributor } from '../../../types/contributors.types'
 
 export default defineComponent({
   components: {
@@ -71,6 +64,16 @@ export default defineComponent({
       }),
       dispatch: injectStore().dispatch,
     }
+  },
+
+  computed: {
+    sortedContributors() {
+      return this.state.contributors.sort((a: PodloveContributor, b: PodloveContributor) => {
+        const aName = a.publicname || a.realname || a.nickname
+        const bName = b.publicname || b.realname || b.nickname
+        return aName.localeCompare(bName)
+      })
+    },
   },
 
   methods: {

--- a/client/src/types/contributors.types.ts
+++ b/client/src/types/contributors.types.ts
@@ -7,6 +7,7 @@ export interface PodloveContributor {
   gender: string
   jobtitle: string
   mail: string
+  publicname: string
   realname: string
   nickname: string
   organisation: string

--- a/lib/modules/transcripts/model/transcript.php
+++ b/lib/modules/transcripts/model/transcript.php
@@ -109,7 +109,15 @@ class Transcript extends \Podlove\Model\Base
     {
         $original_transcript = $transcript;
 
+        // TODO: I think this is how it should be instead.
+        $allow_empty_contributors = true;
+
         $transcript = array_map(function ($t) use ($allow_empty_contributors) {
+            // skip hidden voices
+            if ($t->contributor_id === 4294967295) {
+                return null;
+            }
+
             if (!$t->contributor_id && !$allow_empty_contributors) {
                 return null;
             }

--- a/lib/modules/transcripts/rest_api.php
+++ b/lib/modules/transcripts/rest_api.php
@@ -6,8 +6,6 @@ use Podlove\Model\Episode;
 use Podlove\Modules\Contributors\Model\Contributor;
 use Podlove\Modules\Transcripts\Model\Transcript;
 use Podlove\Modules\Transcripts\Model\VoiceAssignment;
-use WP_REST_Controller;
-use WP_REST_Server;
 
 class REST_API
 {
@@ -91,7 +89,7 @@ class REST_API
     }
 }
 
-class WP_REST_PodloveTranscripts_Controller extends WP_REST_Controller
+class WP_REST_PodloveTranscripts_Controller extends \WP_REST_Controller
 {
     public function __construct()
     {
@@ -124,7 +122,7 @@ class WP_REST_PodloveTranscripts_Controller extends WP_REST_Controller
                         'type' => 'string',
                     ]
                 ],
-                'methods' => WP_REST_Server::READABLE,
+                'methods' => \WP_REST_Server::READABLE,
                 'callback' => [$this, 'get_items'],
                 'permission_callback' => [$this, 'get_item_permissions_check'],
             ],
@@ -136,7 +134,7 @@ class WP_REST_PodloveTranscripts_Controller extends WP_REST_Controller
                         'required' => 'true'
                     ]
                 ],
-                'methods' => WP_REST_Server::CREATABLE,
+                'methods' => \WP_REST_Server::CREATABLE,
                 'callback' => [$this, 'create_item'],
                 'permission_callback' => [$this, 'create_item_permissions_check'],
             ],
@@ -148,12 +146,12 @@ class WP_REST_PodloveTranscripts_Controller extends WP_REST_Controller
                         'required' => 'true'
                     ]
                 ],
-                'methods' => WP_REST_Server::EDITABLE,
+                'methods' => \WP_REST_Server::EDITABLE,
                 'callback' => [$this, 'update_item'],
                 'permission_callback' => [$this, 'update_item_permissions_check'],
             ],
             [
-                'methods' => WP_REST_Server::DELETABLE,
+                'methods' => \WP_REST_Server::DELETABLE,
                 'callback' => [$this, 'delete_item'],
                 'permission_callback' => [$this, 'delete_item_permissions_check'],
             ]
@@ -167,7 +165,7 @@ class WP_REST_PodloveTranscripts_Controller extends WP_REST_Controller
                 ],
             ],
             [
-                'methods' => WP_REST_Server::READABLE,
+                'methods' => \WP_REST_Server::READABLE,
                 'callback' => [$this, 'get_item_voices'],
                 'permission_callback' => [$this, 'get_item_permissions_check'],
             ],
@@ -182,7 +180,7 @@ class WP_REST_PodloveTranscripts_Controller extends WP_REST_Controller
                         'type' => 'integer',
                     ]
                 ],
-                'methods' => WP_REST_Server::EDITABLE,
+                'methods' => \WP_REST_Server::EDITABLE,
                 'callback' => [$this, 'update_item_voices'],
                 'permission_callback' => [$this, 'update_item_permissions_check'],
             ]
@@ -214,7 +212,7 @@ class WP_REST_PodloveTranscripts_Controller extends WP_REST_Controller
                         'type' => 'string',
                     ]
                 ],
-                'methods' => WP_REST_Server::READABLE,
+                'methods' => \WP_REST_Server::READABLE,
                 'callback' => [$this, 'get_item_transcripts'],
                 'permission_callback' => [$this, 'get_item_permissions_check'],
             ],
@@ -236,13 +234,13 @@ class WP_REST_PodloveTranscripts_Controller extends WP_REST_Controller
                     ]
                 ],
                 'description' => __('Edit a chaption of the transcript', 'podlove-podcasting-plugin-for-wordpress'),
-                'methods' => WP_REST_Server::EDITABLE,
+                'methods' => \WP_REST_Server::EDITABLE,
                 'callback' => [$this, 'update_item_transcripts'],
                 'permission_callback' => [$this, 'update_item_permissions_check'],
             ],
             [
                 'description' => __('Delete a chaption of the transcript', 'podlove-podcasting-plugin-for-wordpress'),
-                'methods' => WP_REST_Server::DELETABLE,
+                'methods' => \WP_REST_Server::DELETABLE,
                 'callback' => [$this, 'delete_item_transcripts'],
                 'permission_callback' => [$this, 'delete_item_permissions_check'],
             ]
@@ -528,21 +526,22 @@ class WP_REST_PodloveTranscripts_Controller extends WP_REST_Controller
                 $voice_assignment = new VoiceAssignment();
                 $voice_assignment->episode_id = $episode->id;
                 $voice_assignment->voice = $voice;
-                $voice_assignment->contributer_id = 0;
             }
         }
 
-        $cid = 0;
+        $contributor_id = 0;
 
         if (isset($request['contributor_id'])) {
-            $cid = $request['contributor_id'];
-            $contributor = Contributor::find_by_id($cid);
-            if (!$contributor) {
-                return new \Podlove\Api\Error\NotFound('not_found', 'Contributor is not found');
+            $contributor_id = $request['contributor_id'];
+            if ($contributor_id > 0 && $contributor_id < 4294967295) {
+                $contributor = Contributor::find_by_id($contributor_id);
+                if (!$contributor) {
+                    return new \Podlove\Api\Error\NotFound('not_found', 'Contributor is not found');
+                }
             }
         }
 
-        $voice_assignment->contributor_id = $cid;
+        $voice_assignment->contributor_id = $contributor_id;
         $voice_assignment->save();
 
         return new \Podlove\Api\Response\OkResponse([

--- a/readme.txt
+++ b/readme.txt
@@ -125,6 +125,8 @@ change to appear in the feed and podcatchers. Now, any change to the episode
 metadata or enabling/disabling an asset immediately clears the cache for that
 feed item, resulting in the change to be visible in the RSS feed immediately.
 
+* transcripts: contributors in voices selection are sorted alphabetically
+
 * maintenance: fix various notices from WordPress Plugin Check tool
 
 = 4.1.7 =

--- a/readme.txt
+++ b/readme.txt
@@ -126,6 +126,8 @@ metadata or enabling/disabling an asset immediately clears the cache for that
 feed item, resulting in the change to be visible in the RSS feed immediately.
 
 * transcripts: contributors in voices selection are sorted alphabetically
+* transcripts: voices without assigned contributors appear in transcripts
+* transcripts: add dedicated option to hide a voice from a transcript
 
 * maintenance: fix various notices from WordPress Plugin Check tool
 


### PR DESCRIPTION
### Goals

- by default, if no contributor is assigned/selected, the transcript still works by defaulting to the voice string from the vtt file (instead of an empty transcript)
- add a dedicated option to hide a voice from a transcript

### Notes

- I would usually use something like `-1` for special cases but since `contributor_id` is an `unsigned int`, I use `4294967295` -- which should at least be turned into a constant in the final implementation for readability
- Think about how this change affects users: Not selecting a contributor is not an intended feature, but people may be using it to hide contributors. After this update they might then have unwanted voices appearing in their transcripts.

