### PR TITLE
Spike: Generate whole feed using an XML Generator

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,8 @@
     "geertw/ip-anonymizer": "^1.1",
     "dariuszp/cli-progress-bar": "^1.0",
     "league/csv": "9.8.0",
-    "gajus/dindent": "^2.0"
+    "gajus/dindent": "^2.0",
+    "sabre/xml": "^4.0"
   },
   "require-dev": {
     "pear/pear_exception": "1.0.*@dev",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "11524e3c675cb9a70764a558843715bb",
+    "content-hash": "73615cf931689fdc6fc9c6b01e0131fc",
     "packages": [
         {
             "name": "composer/ca-bundle",
@@ -939,6 +939,135 @@
                 "source": "https://github.com/php-fig/log/tree/3.0.0"
             },
             "time": "2021-07-14T16:46:02+00:00"
+        },
+        {
+            "name": "sabre/uri",
+            "version": "3.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sabre-io/uri.git",
+                "reference": "1774043c843f1db7654ecc93368a98be29b07544"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sabre-io/uri/zipball/1774043c843f1db7654ecc93368a98be29b07544",
+                "reference": "1774043c843f1db7654ecc93368a98be29b07544",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.4 || ^8.0"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "^3.17",
+                "phpstan/extension-installer": "^1.3",
+                "phpstan/phpstan": "^1.10",
+                "phpstan/phpstan-phpunit": "^1.3",
+                "phpstan/phpstan-strict-rules": "^1.5",
+                "phpunit/phpunit": "^9.6"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "lib/functions.php"
+                ],
+                "psr-4": {
+                    "Sabre\\Uri\\": "lib/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Evert Pot",
+                    "email": "me@evertpot.com",
+                    "homepage": "http://evertpot.com/",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Functions for making sense out of URIs.",
+            "homepage": "http://sabre.io/uri/",
+            "keywords": [
+                "rfc3986",
+                "uri",
+                "url"
+            ],
+            "support": {
+                "forum": "https://groups.google.com/group/sabredav-discuss",
+                "issues": "https://github.com/sabre-io/uri/issues",
+                "source": "https://github.com/fruux/sabre-uri"
+            },
+            "time": "2023-06-09T07:04:02+00:00"
+        },
+        {
+            "name": "sabre/xml",
+            "version": "4.0.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sabre-io/xml.git",
+                "reference": "c29e49fcf9ca8ca058b1e350ee9abe4205c0de89"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sabre-io/xml/zipball/c29e49fcf9ca8ca058b1e350ee9abe4205c0de89",
+                "reference": "c29e49fcf9ca8ca058b1e350ee9abe4205c0de89",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-xmlreader": "*",
+                "ext-xmlwriter": "*",
+                "lib-libxml": ">=2.6.20",
+                "php": "^7.4 || ^8.0",
+                "sabre/uri": ">=2.0,<4.0.0"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "^3.51",
+                "phpstan/phpstan": "^1.10",
+                "phpunit/phpunit": "^9.6"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "lib/Deserializer/functions.php",
+                    "lib/Serializer/functions.php"
+                ],
+                "psr-4": {
+                    "Sabre\\Xml\\": "lib/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Evert Pot",
+                    "email": "me@evertpot.com",
+                    "homepage": "http://evertpot.com/",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Markus Staab",
+                    "email": "markus.staab@redaxo.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "sabre/xml is an XML library that you may not hate.",
+            "homepage": "https://sabre.io/xml/",
+            "keywords": [
+                "XMLReader",
+                "XMLWriter",
+                "dom",
+                "xml"
+            ],
+            "support": {
+                "forum": "https://groups.google.com/group/sabredav-discuss",
+                "issues": "https://github.com/sabre-io/xml/issues",
+                "source": "https://github.com/fruux/sabre-xml"
+            },
+            "time": "2024-04-18T10:44:25+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",

--- a/lib/feeds.php
+++ b/lib/feeds.php
@@ -15,7 +15,8 @@ function register_podcast_feeds()
 {
     foreach (Model\Feed::all() as $feed) {
         if ($feed->slug) {
-            add_feed($feed->slug, '\\Podlove\\Feeds\\generate_podcast_feed');
+            add_feed($feed->slug.'-legacy', '\\Podlove\\Feeds\\generate_podcast_feed');
+            add_feed($feed->slug, '\\Podlove\\Feeds\\generate_sparkling_podcast_feed');
         }
     }
 }
@@ -168,6 +169,13 @@ function generate_podcast_feed()
     remove_podPress_hooks();
     remove_powerPress_hooks();
     RSS::render();
+}
+
+function generate_sparkling_podcast_feed()
+{
+    $generator = new \Podlove\RSS\Generator();
+    $generator->generate();
+    exit;
 }
 
 function check_for_and_do_compression($content_type = 'application/rss+xml')

--- a/lib/feeds/legacy.txt
+++ b/lib/feeds/legacy.txt
@@ -1,0 +1,2 @@
+This directory is deprecated.
+Superceeded by lib/rss.

--- a/lib/rss/element/rss.php
+++ b/lib/rss/element/rss.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Podlove\RSS\Element;
+
+class RSS implements \Sabre\Xml\XmlSerializable
+{
+    public $value;
+
+    public function __construct($value)
+    {
+        $this->value = $value;
+    }
+
+    public function xmlSerialize(\Sabre\Xml\Writer $writer): void
+    {
+        $writer->writeAttribute('version', '2.0');
+        $writer->write($this->value);
+    }
+}

--- a/lib/rss/generator.php
+++ b/lib/rss/generator.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace Podlove\RSS;
+
+use Podlove\Model;
+use Sabre\Xml\Element\Cdata;
+
+final class Generator
+{
+    const NS_ATOM = '{http://www.w3.org/2005/Atom}';
+    const NS_ITUNES = '{http://www.itunes.com/dtds/podcast-1.0.dtd}';
+    private $podcast;
+
+    public function __construct()
+    {
+        $this->podcast = Model\Podcast::get();
+    }
+
+    public function generate(): void
+    {
+        $service = new \Sabre\Xml\Service();
+        $service->namespaceMap = [
+            'http://www.w3.org/2005/Atom' => 'atom',
+            'http://www.itunes.com/dtds/podcast-1.0.dtd' => 'itunes'
+        ];
+
+        $xml = $service->write('rss', new Element\RSS([
+            'channel' => [
+                ...$this->channel(),
+                ...$this->items()
+            ]
+        ]));
+
+        header('Content-Type: application/rss+xml; charset=UTF-8', true);
+        echo $xml;
+        exit;
+    }
+
+    private function channel()
+    {
+        return [
+            'title' => apply_filters('podlove_feed_title', ''),
+            'link' => apply_filters('podlove_feed_link', \Podlove\get_landing_page_url()),
+            'description' => new Cdata($this->podcast->summary),
+            'lastBuildDate' => mysql2date('D, d M Y H:i:s +0000', get_lastpostmodified('GMT'), false),
+            'generator' => \Podlove\get_plugin_header('Name').' v'.\Podlove\get_plugin_header('Version'),
+            'copyright' => apply_filters('podlove_feed_copyright', $this->podcast->copyright ?? $this->podcast->default_copyright_claim()),
+            self::NS_ITUNES.'author' => apply_filters('podlove_feed_itunes_author', $this->podcast->author_name),
+            self::NS_ITUNES.'type' => apply_filters('podlove_feed_itunes_type', in_array($this->podcast->itunes_type, ['episodic', 'serial']) ? $this->podcast->itunes_type : 'episodic'),
+            self::NS_ITUNES.'summary' => apply_filters('podlove_feed_itunes_summary', $this->podcast->summary),
+        ];
+    }
+
+    // NOTE: This uses/requires The WordPress Loop
+    private function items()
+    {
+        $items = [];
+
+        while (have_posts()) {
+            the_post();
+
+            $items[] = [
+                'name' => 'item',
+                'value' => [
+                    'title' => \Podlove\Feeds\get_episode_title(),
+                    'link' => get_permalink(),
+                    'pubDate' => mysql2date('D, d M Y H:i:s +0000', get_post_time('Y-m-d H:i:s', true), false),
+                    'guid' => [
+                        'attributes' => ['isPermalink' => 'false'],
+                        'value' => get_the_guid()
+                    ]
+                ]
+            ];
+        }
+
+        return $items;
+    }
+}


### PR DESCRIPTION
Since the beginning of the plugin, we generated RSS the same way WordPress does: with templates. Gradually, we started to generate element by element using XML generator functions, but the main feed remained a template.

This Spike explores generating the whole RSS Feed using an XML generator, guaranteeing valid XML.