### PR TITLE
ci: publish docker images for branches

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+!/dist
+vendor
+vendor-prefixed

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,0 +1,59 @@
+# https://docs.github.com/en/actions/publishing-packages/publishing-docker-images#publishing-images-to-github-packages
+name: Create and publish a Docker image
+
+# Configures this workflow to run every time a change is pushed to the branch called `release`.
+on:
+  push:
+    branches: ['beta', 'master']
+
+# Defines two custom environment variables for the workflow. These are used for the Container registry domain, and a name for the Docker image that this workflow builds.
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+# There is a single job in this workflow. It's configured to run on the latest available version of Ubuntu.
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+    # Sets the permissions granted to the `GITHUB_TOKEN` for the actions in this job.
+    permissions:
+      contents: read
+      packages: write
+      attestations: write
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install devbox
+        uses: jetify-com/devbox-install-action@v0.11.0
+
+      - name: Bootstrap Podlove Publisher
+        run: devbox run bootstrap
+
+      - name: Build Podlove Publisher
+        run: devbox run build
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3.2.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5.5.1
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      - name: Build and push Docker image
+        id: push
+        uses: docker/build-push-action@v6.1.0
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+FROM wordpress:6-php8.1-apache
+
+RUN apt-get update
+RUN apt-get install zip default-mysql-client -y
+
+RUN curl -O https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar
+RUN chmod +x wp-cli.phar
+RUN mv wp-cli.phar /usr/local/bin/wp
+
+WORKDIR /var/www/html
+
+COPY ./bin/docker-entry.sh /usr/local/bin/entry.sh
+COPY ./bin/docker-setup.sh /usr/local/bin/setup.sh
+COPY ./dist /tmp/podlove-podcasting-plugin-for-wordpress
+RUN cd /tmp/podlove-podcasting-plugin-for-wordpress && zip -r /tmp/podlove-podcasting-plugin-for-wordpress.zip .
+RUN rm -rf /tmp/podlove-podcasting-plugin-for-wordpress
+
+ENTRYPOINT ["entry.sh"]

--- a/bin/docker-entry.sh
+++ b/bin/docker-entry.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# Waiting for the MySQL server to start
+while ! wp db check --allow-root &>/dev/null; do \
+    sleep 0.1; \
+done; \
+
+# Running the WordPress installation process
+wp core install --allow-root --url=http://127.0.0.1:8080 --path=/var/www/html --title="Podlove Publisher E2E Test Environment" --admin_email=admin@example.com --admin_user=admin --admin_password=admin --skip-email
+wp plugin install --activate --allow-root --path=/var/www/html /tmp/podlove-podcasting-plugin-for-wordpress.zip
+
+eval setup.sh
+eval docker-entrypoint.sh "apache2-foreground"

--- a/bin/docker-setup.sh
+++ b/bin/docker-setup.sh
@@ -1,0 +1,1 @@
+#!/usr/bin/env bash

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,40 @@
+services:
+  db:
+    image: mysql:latest
+    container_name: db
+    restart: unless-stopped
+    environment:
+      MYSQL_DATABASE: wordpress
+      MYSQL_ROOT_PASSWORD: wordpress
+      MYSQL_USER: wordpress
+      MYSQL_PASSWORD: wordpress
+    expose:
+      - 3306
+    networks:
+      - app-network
+
+  wordpress:
+    build: .
+
+    ports:
+      - 8080:80
+    restart: always
+    depends_on:
+      - db
+    environment:
+      WORDPRESS_DB_HOST: db:3306
+      WORDPRESS_DB_USER: wordpress
+      WORDPRESS_DB_PASSWORD: wordpress
+      WORDPRESS_DB_NAME: wordpress
+
+    volumes:
+      - wp-data:/var/www/html/
+    networks:
+      - app-network
+
+networks:
+  app-network:
+    driver: bridge
+
+volumes:
+  wp-data:


### PR DESCRIPTION
- creates a docker image (`ghcr.io/podlove/podlove-publisher:[beta|master]`) on each push to master or beta
- docker image will create a wordpress instance with a user (admin:admin) and the publisher preinstalled and activated