### PR TITLE
feat(onboarding) - Set default settings

### DIFF
--- a/lib/modules/onboarding/onboarding.php
+++ b/lib/modules/onboarding/onboarding.php
@@ -3,7 +3,7 @@
 namespace Podlove\Modules\Onboarding;
 
 use Podlove\Modules\Onboarding\Settings\OnboardingPage;
-use Podlove\Api\Admin\WP_REST_PodloveOnboarding_Controller;
+use Podlove\Modules\Onboarding\WP_REST_PodloveOnboarding_Controller;
 
 class Onboarding extends \Podlove\Modules\Base
 {

--- a/lib/modules/onboarding/rest_api.php
+++ b/lib/modules/onboarding/rest_api.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Podlove\Modules\Onboarding;
+
+use Podlove\Modules\WordpressFileUpload\Wordpress_File_Upload;
+use WP_REST_Controller;
+
+class WP_REST_PodloveOnboarding_Controller extends WP_REST_Controller
+{
+    /**
+     * Constructor.
+     */
+    public function __construct()
+    {
+        $this->namespace = 'podlove/v2';
+        $this->rest_base = 'onboarding';
+    }
+
+    /**
+     * Register the component routes.
+     */
+    public function register_routes()
+    {
+        register_rest_route($this->namespace, $this->rest_base, [
+            [
+                'methods' => \WP_REST_SERVER::EDITABLE,
+                'callback' => [$this, 'update_items'],
+                'permission_callback' => [$this, 'update_permissions_check']
+            ]
+
+        ]);
+    }
+
+    public function update_items($request)
+    {
+        if (!\Podlove\Modules\Base::is_active('wordpress_file_upload')) {
+            \Podlove\Modules\Base::activate('wordpress_file_upload');
+            $upload_modul = Wordpress_File_Upload::instance();
+            $upload_modul->update_module_option('upload_subdir', 'podlove-media');
+        }
+    }
+    public function update_permissions_check($request)
+    {
+        if (!current_user_can('edit_posts')) {
+            return new \Podlove\Api\Error\ForbiddenAccess();
+        }
+
+        return true;
+    }
+}

--- a/lib/modules/onboarding/rest_api.php
+++ b/lib/modules/onboarding/rest_api.php
@@ -21,24 +21,29 @@ class WP_REST_PodloveOnboarding_Controller extends WP_REST_Controller
      */
     public function register_routes()
     {
-        register_rest_route($this->namespace, $this->rest_base, [
+        register_rest_route($this->namespace, $this->rest_base."/setup", [
             [
                 'methods' => \WP_REST_SERVER::EDITABLE,
                 'callback' => [$this, 'update_items'],
                 'permission_callback' => [$this, 'update_permissions_check']
             ]
-
         ]);
     }
 
     public function update_items($request)
     {
+        // activate File-Upload-Module and set default settings
         if (!\Podlove\Modules\Base::is_active('wordpress_file_upload')) {
             \Podlove\Modules\Base::activate('wordpress_file_upload');
-            $upload_modul = Wordpress_File_Upload::instance();
-            $upload_modul->update_module_option('upload_subdir', 'podlove-media');
         }
+        $upload_modul = Wordpress_File_Upload::instance();
+        $upload_modul->update_module_option('upload_subdir', 'podlove-media');
+        // set upload loaction to emty
+        $settings = get_option('podlove_podcast');
+        $settings["media_file_base_uri"] = "";
+        update_option('podlove_podcast', $settings);
     }
+
     public function update_permissions_check($request)
     {
         if (!current_user_can('edit_posts')) {


### PR DESCRIPTION
Ich habe einen API Endpunkt angelegt mit dem während des Onboardings die nötigen Einstellungen vorgenommen werden können. Aktuell wird nur das File Upload Modul aktiviert und ein default Verzeichnis gesetzt. Beim Import sollte falls nötig noch das Transcript- und Contributor-Modul aktiviert werden.