### PR TITLE
fix: unescape Gutenberg title value

### DIFF
--- a/client/src/lib/wordpress.ts
+++ b/client/src/lib/wordpress.ts
@@ -2,5 +2,6 @@ import { get } from 'lodash'
 
 export const store = get(window, ['wp', 'data'], null)
 export const media = get(window, ['wp', 'media'], null)
+export const htmlEntities = get(window, ['wp', 'htmlEntities'], null)
 export const postTitleInput: HTMLInputElement | null = document.querySelector('input[name="post_title"]')
 export const postTitleListener = (cb: (title: string) => any) => postTitleInput?.addEventListener('change', event => cb(get(event, ['target', 'value'])))

--- a/client/src/sagas/wordpress.sagas.ts
+++ b/client/src/sagas/wordpress.sagas.ts
@@ -36,7 +36,9 @@ function* wordpressGutenbergUpdate() {
   yield put(
     wordpressStore.update({
       prop: 'title',
-      value: wordpress.store.select('core/editor').getEditedPostAttribute('title'),
+      value: wordpress.htmlEntities.decodeEntities(
+        wordpress.store.select('core/editor').getEditedPostAttribute('title')
+      ),
     })
   )
 }


### PR DESCRIPTION
issue #1495

Get ready for some WordPress nonsense.

The Gutenberg editor has two modes: *visual* and *code*. We access the title data with its official API: `select('core/editor').getEditedPostAttribute('title')`.

**Scenario:** User types `Foo & Bar` into the title field.

In the *code* mode (the one probably barely anyone uses), the behavior is as expected. The value is `Foo & Bar`. 

In the *visual* mode, the value is ... 🥁 ... escaped! `Foo &amp; Bar`!

So the user types the same thing, but the end value in the JS API is different, depending on a view mode? Makes total sense! Anyway, we use `htmlEntities.decodeEntities` then when accessing the title value to ensure the title is always unescaped. Looks fine in the frontend now (and that's the current state of this PR).

All good now? God no! Because _WordPress actually persists the escaped title data in the database!_ So the title data in the feed is broken. Needs some more work and testing of various settings to ensure the value in the feed is always correct. And maybe check if only `&` is affected or also emojis etc.