### PR TITLE
fix(episode) - expicit tag was not stored

### DIFF
--- a/client/src/store/episode.store.ts
+++ b/client/src/store/episode.store.ts
@@ -131,6 +131,7 @@ export const reducer = handleActions(
         'show',
         'number',
         'episode_poster',
+        'explicit',
       ]
 
       if (simple.includes(prop)) {

--- a/includes/api/episodes.php
+++ b/includes/api/episodes.php
@@ -764,11 +764,21 @@ class WP_REST_PodloveEpisode_Controller extends \WP_REST_Controller
 
         if (isset($request['explicit'])) {
             $explicit = $request['explicit'];
-            $explicit_lowercase = strtolower($explicit);
-            if ($explicit_lowercase == 'false') {
-                $episode->explicit = 0;
-            } elseif ($explicit_lowercase == 'true') {
-                $episode->explicit = 1;
+            if (is_string($explicit)) {
+                $explicit_lowercase = strtolower($explicit);
+                if ($explicit_lowercase == 'true') {
+                    $episode->explicit = 1;
+                } elseif ($explicit_lowercase == 'false') {
+                    $episode->explicit = 0;
+                }
+            }
+            else {
+                if ($explicit) {
+                    $episode->explicit = 1;
+                }
+                else {
+                    $episode->explicit = 0;
+                }
             }
         }
 


### PR DESCRIPTION
Fix #1490 
PR #1464 was not enough. Explicit item was net set and in the RestAPI was a type mismatch. 