### PR TITLE
Add null check before call ucfirst

### DIFF
--- a/lib/modules/contributors/contributor_list_table.php
+++ b/lib/modules/contributors/contributor_list_table.php
@@ -49,7 +49,7 @@ class Contributor_List_Table extends \Podlove\List_Table
 
     public function column_gender($contributor)
     {
-        if ($contributor->gender == 'none') {
+        if ($contributor->gender === null || $contributor->gender == 'none') {
             return 'Not set';
         }
 


### PR DESCRIPTION
Wurde ein Podcast mit Kontributoren importiert, so ist bei den Kontributoren das Feld gender nicht gesetzt. Das führt ab php 8.1 zu einer Warnung in der Kontributoren-Tabelle. 