### PR TITLE
Fix/remove db tables

### DIFF
--- a/lib/model/base.php
+++ b/lib/model/base.php
@@ -495,7 +495,7 @@ abstract class Base
     public static function destroy()
     {
         global $wpdb;
-        $wpdb->query('DROP TABLE '.static::table_name());
+        $wpdb->query('DROP TABLE IF EXISTS '.static::table_name());
     }
 
     public static function delete_all($reset_autoincrement = true)

--- a/lib/modules/analytics_heartbeat/analytics_heartbeat.php
+++ b/lib/modules/analytics_heartbeat/analytics_heartbeat.php
@@ -32,6 +32,11 @@ class Analytics_Heartbeat extends \Podlove\Modules\Base
         }
     }
 
+    public function uninstall()
+    {
+        Heartbeat::destroy();
+    }
+
     public function check_analytics_status()
     {
         Heartbeat::build();

--- a/lib/modules/base.php
+++ b/lib/modules/base.php
@@ -40,6 +40,13 @@ abstract class Base
     abstract public function load();
 
     /**
+     * This will be called when the plugin is uninstalled.
+     *
+     * Modules can override this to drop their own tables or remove persistent data.
+     */
+    public function uninstall() {}
+
+    /**
      * Fetch module names by iterating over module directories.
      *
      * @return array

--- a/lib/modules/contributors/contributors.php
+++ b/lib/modules/contributors/contributors.php
@@ -20,7 +20,6 @@ class Contributors extends \Podlove\Modules\Base
 
     public function load()
     {
-        add_action('podlove_uninstall_plugin', [$this, 'uninstall']);
         add_action('podlove_module_was_activated_contributors', [$this, 'was_activated']);
         add_filter('podlove_episode_form_data', [$this, 'contributors_form_for_episode'], 10, 2);
         add_action('save_post', [$this, 'update_contributors'], 10, 2);

--- a/lib/modules/logging/logging.php
+++ b/lib/modules/logging/logging.php
@@ -19,7 +19,6 @@ class Logging extends \Podlove\Modules\Base
 
     public function load()
     {
-        add_action('podlove_uninstall_plugin', [$this, 'uninstall']);
         add_action('podlove_module_was_activated_logging', [$this, 'was_activated']);
         add_action('init', [$this, 'register_database_logger']);
 

--- a/lib/modules/networks/networks.php
+++ b/lib/modules/networks/networks.php
@@ -87,6 +87,13 @@ class Networks extends \Podlove\Modules\Base
         });
     }
 
+    public function uninstall()
+    {
+        PodcastList::with_network_scope(function () {
+            PodcastList::destroy();
+        });
+    }
+
     // Register Network Admin Menu
     public function create_network_menu()
     {

--- a/lib/modules/related_episodes/related_episodes.php
+++ b/lib/modules/related_episodes/related_episodes.php
@@ -35,6 +35,11 @@ class Related_Episodes extends \Podlove\Modules\Base
         Shortcodes::init();
     }
 
+    public function uninstall()
+    {
+        EpisodeRelation::destroy();
+    }
+
     public function was_activated($module_name)
     {
         EpisodeRelation::build();

--- a/lib/modules/seasons/seasons.php
+++ b/lib/modules/seasons/seasons.php
@@ -58,6 +58,11 @@ class Seasons extends \Podlove\Modules\Base
         Season::build();
     }
 
+    public function uninstall()
+    {
+        Season::destroy();
+    }
+
     public function scripts_and_styles()
     {
         $is_seasons_settings_page = filter_input(INPUT_GET, 'page') === 'podlove_seasons_settings';

--- a/lib/modules/shownotes/shownotes.php
+++ b/lib/modules/shownotes/shownotes.php
@@ -45,6 +45,11 @@ class Shownotes extends \Podlove\Modules\Base
         Entry::build();
     }
 
+    public function uninstall()
+    {
+        Entry::destroy();
+    }
+
     public function add_meta_box()
     {
         $post_id = get_the_ID();

--- a/lib/modules/social/social.php
+++ b/lib/modules/social/social.php
@@ -76,6 +76,13 @@ class Social extends \Podlove\Modules\Base
         self::build_missing_services();
     }
 
+    public function uninstall()
+    {
+        Service::destroy();
+        ShowService::destroy();
+        ContributorService::destroy();
+    }
+
     public static function services_config()
     {
         $file = implode(

--- a/lib/modules/transcripts/transcripts.php
+++ b/lib/modules/transcripts/transcripts.php
@@ -98,6 +98,12 @@ class Transcripts extends \Podlove\Modules\Base
         return \Podlove\Template\TwigFilter::apply_to_html('@transcripts/transcript.twig', ['episode' => $episode]);
     }
 
+    public function uninstall()
+    {
+        Transcript::destroy();
+        VoiceAssignment::destroy();
+    }
+
     public function was_activated($module_name)
     {
         Transcript::build();

--- a/plugin.php
+++ b/plugin.php
@@ -115,10 +115,23 @@ function uninstall()
             }
             switch_to_blog($current_blog);
         } else {
-            activate_for_current_blog();
+            uninstall_for_current_blog();
         }
     } else {
         uninstall_for_current_blog();
+    }
+}
+
+function uninstall_modules_for_current_blog()
+{
+    $modules = \Podlove\Modules\Base::get_all_module_names();
+
+    foreach ($modules as $module_name) {
+        $class = \Podlove\Modules\Base::get_class_by_module_name($module_name);
+
+        if (class_exists($class)) {
+            $class::instance()->uninstall();
+        }
     }
 }
 
@@ -127,6 +140,7 @@ function uninstall_for_current_blog()
     global $wpdb;
 
     \Podlove\Cache\TemplateCache::get_instance()->purge();
+    uninstall_modules_for_current_blog();
 
     Model\Feed::destroy();
     Model\FileType::destroy();
@@ -139,7 +153,9 @@ function uninstall_for_current_blog()
     Model\UserAgent::destroy();
     Model\GeoArea::destroy();
     Model\GeoAreaName::destroy();
+    Model\Job::destroy();
 
+    // Legacy hook for external integrations that still rely on it.
     do_action('podlove_uninstall_plugin');
 
     // trash all episodes

--- a/tests/phpunit/integration/ModuleUninstallTest.php
+++ b/tests/phpunit/integration/ModuleUninstallTest.php
@@ -1,0 +1,99 @@
+<?php
+
+/**
+ * @internal
+ *
+ * @coversNothing
+ */
+class ModuleUninstallTest extends WP_UnitTestCase
+{
+    protected function tearDown(): void
+    {
+        \Podlove\Modules\Social\Model\Service::destroy();
+        \Podlove\Modules\Social\Model\ShowService::destroy();
+        \Podlove\Modules\Social\Model\ContributorService::destroy();
+        \Podlove\Modules\Shownotes\Model\Entry::destroy();
+        \Podlove\Modules\Seasons\Model\Season::destroy();
+        \Podlove\Modules\AnalyticsHeartbeat\Model\Heartbeat::destroy();
+
+        \Podlove\Modules\Networks\Model\PodcastList::with_network_scope(function () {
+            \Podlove\Modules\Networks\Model\PodcastList::destroy();
+        });
+
+        parent::tearDown();
+    }
+
+    public function testSocialUninstallRemovesAllModuleTables()
+    {
+        \Podlove\Modules\Social\Model\Service::build();
+        \Podlove\Modules\Social\Model\ShowService::build();
+        \Podlove\Modules\Social\Model\ContributorService::build();
+
+        $this->assertTrue(\Podlove\Modules\Social\Model\Service::table_exists());
+        $this->assertTrue(\Podlove\Modules\Social\Model\ShowService::table_exists());
+        $this->assertTrue(\Podlove\Modules\Social\Model\ContributorService::table_exists());
+
+        \Podlove\Modules\Social\Social::instance()->uninstall();
+
+        $this->assertFalse(\Podlove\Modules\Social\Model\Service::table_exists());
+        $this->assertFalse(\Podlove\Modules\Social\Model\ShowService::table_exists());
+        $this->assertFalse(\Podlove\Modules\Social\Model\ContributorService::table_exists());
+    }
+
+    public function testShownotesUninstallRemovesEntryTable()
+    {
+        \Podlove\Modules\Shownotes\Model\Entry::build();
+
+        $this->assertTrue(\Podlove\Modules\Shownotes\Model\Entry::table_exists());
+
+        \Podlove\Modules\Shownotes\Shownotes::instance()->uninstall();
+
+        $this->assertFalse(\Podlove\Modules\Shownotes\Model\Entry::table_exists());
+    }
+
+    public function testSeasonsUninstallRemovesSeasonTable()
+    {
+        \Podlove\Modules\Seasons\Model\Season::build();
+
+        $this->assertTrue(\Podlove\Modules\Seasons\Model\Season::table_exists());
+
+        \Podlove\Modules\Seasons\Seasons::instance()->uninstall();
+
+        $this->assertFalse(\Podlove\Modules\Seasons\Model\Season::table_exists());
+    }
+
+    public function testAnalyticsHeartbeatUninstallRemovesHeartbeatTable()
+    {
+        \Podlove\Modules\AnalyticsHeartbeat\Model\Heartbeat::build();
+
+        $this->assertTrue(\Podlove\Modules\AnalyticsHeartbeat\Model\Heartbeat::table_exists());
+
+        \Podlove\Modules\AnalyticsHeartbeat\Analytics_Heartbeat::instance()->uninstall();
+
+        $this->assertFalse(\Podlove\Modules\AnalyticsHeartbeat\Model\Heartbeat::table_exists());
+    }
+
+    public function testNetworksUninstallRemovesNetworkPodcastListTable()
+    {
+        \Podlove\Modules\Networks\Model\PodcastList::with_network_scope(function () {
+            \Podlove\Modules\Networks\Model\PodcastList::build();
+        });
+
+        $this->assertTrue($this->networkPodcastListTableExists());
+
+        \Podlove\Modules\Networks\Networks::instance()->uninstall();
+
+        $this->assertFalse($this->networkPodcastListTableExists());
+    }
+
+    private function networkPodcastListTableExists(): bool
+    {
+        global $wpdb;
+
+        return \Podlove\Modules\Networks\Model\PodcastList::with_network_scope(function () use ($wpdb) {
+            $sql = $wpdb->prepare('SHOW TABLES LIKE %s', \Podlove\esc_like(\Podlove\Modules\Networks\Model\PodcastList::table_name()));
+
+            return $wpdb->get_var($sql) !== null;
+        });
+    }
+}


### PR DESCRIPTION
Whilst testing PR #1587, I noticed that some database tables remain after the plugin is deleted. This PR aims to resolve that issue. 