### PR TITLE
fix: image resize cache filename if height or width is empty

### DIFF
--- a/lib/model/image.php
+++ b/lib/model/image.php
@@ -337,11 +337,9 @@ class Image
         $orig_sizes = $image->get_size();
         $original = $orig_sizes['width'].'x'.$orig_sizes['height'];
 
-        if (!$this->height) {
+        if (!$this->height && !$this->width) {
+            //keep original size
             $this->height = $orig_sizes['height'];
-        }
-
-        if (!$this->width) {
             $this->width = $orig_sizes['width'];
         }
 


### PR DESCRIPTION
The cache filename should not contain `width` or `height`, if not provided. Otherwise `$this->resized_file()` returns different filenames before and after resize on new `Image` Objects. I think this should also fix cache aspect ratio.

Before:
```php
// get url, resized to 100px width, keep aspect ratio (orig size 200x200) 
$image = (new Image('test.png'))->setWidth(100)->url(); 
$image->generate_resized_copy();
// saved image = ...test_100x200.png
$image_cached = (new Image($url))->setWidth(100)->url(); 
// loaded image = ...test.png (cached $this->resized_file() = ...test_100x.png not found)
```

After:
```php
// get url, resized to 100px width, keep aspect ratio (orig size 200x200) 
$image = (new Image('test.png'))->setWidth(100)->url(); 
$image->generate_resized_copy();
// saved image = ...test_100x.png
$image_cached = (new Image($url))->setWidth(100)->url();
 // loaded image = ...test_100x.png (uses cached resized image)
```